### PR TITLE
Add defaults to sprite in create_sprite

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,7 @@ fn create_sprite(
         mesh: meshes.add(geometry.into()),
         sprite: Sprite {
             size: Vec2::new(1.0, 1.0),
+            ..Default::default()
         },
         translation,
         ..Default::default()


### PR DESCRIPTION
The current version of this ~~crate~~ repo(?) fails to build with the latest github version of bevy as `Sprite` doesn't have `resize_mode` defined. 

Adding defaults fixes the issue on the master branch of bevy. I haven't tested this with bevy `0.1.3`.