### PR TITLE
Fix readme example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ use bevy_prototype_lyon::prelude::*;
 
 fn main() {
     App::build()
-        .add_default_plugins()
+        .add_plugins(DefaultPlugins)
         .add_startup_system(setup.system())
         .run();
 }
@@ -46,7 +46,7 @@ fn setup(
             material.clone(),
             &mut meshes,
             ShapeType::Circle(60.0),
-            TessellationMode::Fill(&FillOptions::default())
+            TessellationMode::Fill(&FillOptions::default()),
             Vec3::new(0.0, 0.0, 0.0).into(),
         ));
 }


### PR DESCRIPTION
Two issues:

1) missing comma on penultimate argument,
2) `add_default_plugins()` instead of `.add_plugins(DefaultPlugins)` (a backwards-incompatible [bevy 0.3 change](https://bevyengine.org/news/bevy-0-3/#plugin-groups).)

After fixing those two issues, the example works on my machine (red circle on grey background).