### PR TITLE
Make Polygon draw work

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,7 @@ pub trait ShapeSprite {
         transform: Transform,
     ) -> (ShapeDescriptor,)
     where
-        Self: Sync + Send + Sized + Copy + 'static,
+        Self: Sync + Send + Sized + Clone + 'static,
     {
         let desc = ShapeDescriptor {
             shape: Box::new(self.clone()),

--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -121,7 +121,7 @@ impl ShapeSprite for Ellipse {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Polygon {
     pub points: Vec<Vec2>,
     pub closed: bool,


### PR DESCRIPTION
`Polygon` uses a `Vec` inside, and thus isn't `Copy`-able and can't be made `Copy`. This means the `draw` method wouldn't work as this required `Copy`. `Polygon` can be made to support Clone. So loosen restrictions to work with `Clone`.