### PR TITLE
Preserve entity when instantiating ShapeDescriptors

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -112,6 +112,7 @@ fn shapesprite_maker(
             ..Default::default()
         };
 
-        commands.spawn(sprite_bundle).despawn(entity);
+        commands.insert(entity, sprite_bundle);
+        commands.remove_one::<ShapeDescriptor>(entity);
     }
 }


### PR DESCRIPTION
This change removes the ShapeDescriptor from entities and attaches the new SpriteBundle to them rather than despawning and respawning the entire entity. This allows user code to attach components to the entity, store it's Entity for future use or place it in a hierarchy.

There is some cost to changing the entity's archetype but I suspect it's not meaningfully different than the cost of despawning and creating a new entity, possibly less. I believe Cart is currently working on changes to the ECS that make that cost even smaller so I don't think it's a concern unless there is evidence of a problem.