### PR TITLE
General refactoring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,7 @@ version = "0.1.5"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-# bevy = {version = "0.4", default-features = false, features = ["render"]}
-bevy_app = "0.4"
-bevy_asset = "0.4"
-bevy_ecs = "0.4"
-bevy_math = "0.4"
-bevy_render = "0.4"
-bevy_sprite = "0.4"
-bevy_transform = "0.4"
+bevy = {version = "0.4", default-features = false, features = ["render"]}
 
 lyon_tessellation = "0.17"
 

--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -2,7 +2,7 @@
 use bevy::math::Vec2;
 use lyon_tessellation::math::{Point, Vector};
 
-/// A locally defined [std::convert::Into] surrogate to overcome orphan rules.
+/// A locally defined [`std::convert::Into`] surrogate to overcome orphan rules.
 pub trait Convert<T>: Sized {
     /// Converts the value to `T`.
     fn convert(self) -> T;

--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -1,5 +1,5 @@
 //! Conversions between Bevy and Lyon datatypes.
-use bevy_math::Vec2;
+use bevy::math::Vec2;
 use lyon_tessellation::math::{Point, Vector};
 
 /// A locally defined [std::convert::Into] surrogate to overcome orphan rules.

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -1,0 +1,52 @@
+//! Custom [`Bundle`] for shapes.
+
+use bevy::{
+    asset::Handle,
+    ecs::Bundle,
+    render::{
+        draw::{Draw, Visible},
+        mesh::Mesh,
+        pipeline::{RenderPipeline, RenderPipelines},
+        render_graph::base::MainPass,
+    },
+    sprite::{ColorMaterial, Sprite, QUAD_HANDLE, SPRITE_PIPELINE_HANDLE},
+    transform::components::{GlobalTransform, Transform},
+};
+use lyon_tessellation::path::Path;
+
+#[allow(missing_docs)]
+#[derive(Bundle)]
+pub struct ShapeBundle {
+    pub path: Path,
+    pub sprite: Sprite,
+    pub mesh: Handle<Mesh>,
+    pub material: Handle<ColorMaterial>,
+    pub main_pass: MainPass,
+    pub draw: Draw,
+    pub visible: Visible,
+    pub render_pipelines: RenderPipelines,
+    pub transform: Transform,
+    pub global_transform: GlobalTransform,
+}
+
+impl Default for ShapeBundle {
+    fn default() -> Self {
+        Self {
+            path: Path::new(),
+            mesh: QUAD_HANDLE.typed(),
+            render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
+                SPRITE_PIPELINE_HANDLE.typed(),
+            )]),
+            visible: Visible {
+                is_visible: false, // TODO: Remember to set to true in shapesprite_maker!!!
+                is_transparent: true,
+            },
+            main_pass: MainPass,
+            draw: Default::default(),
+            sprite: Default::default(),
+            material: Default::default(),
+            transform: Default::default(),
+            global_transform: Default::default(),
+        }
+    }
+}

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -3,6 +3,7 @@
 use bevy::{
     asset::Handle,
     ecs::Bundle,
+    math::Vec2,
     render::{
         draw::{Draw, Visible},
         mesh::Mesh,
@@ -12,12 +13,18 @@ use bevy::{
     sprite::{ColorMaterial, Sprite, QUAD_HANDLE, SPRITE_PIPELINE_HANDLE},
     transform::components::{GlobalTransform, Transform},
 };
-use lyon_tessellation::path::Path;
+use lyon_tessellation::{path::Path, FillOptions};
 
+use crate::plugin::TessellationMode;
+
+// FIXME: Make a Processed(bool) component to prevent creating meshes
+// indefinitely.
+/// A [`Bundle`] that represents a shape.
 #[allow(missing_docs)]
 #[derive(Bundle)]
 pub struct ShapeBundle {
     pub path: Path,
+    pub mode: TessellationMode,
     pub sprite: Sprite,
     pub mesh: Handle<Mesh>,
     pub material: Handle<ColorMaterial>,
@@ -33,17 +40,21 @@ impl Default for ShapeBundle {
     fn default() -> Self {
         Self {
             path: Path::new(),
+            mode: TessellationMode::Fill(FillOptions::default()),
             mesh: QUAD_HANDLE.typed(),
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
                 SPRITE_PIPELINE_HANDLE.typed(),
             )]),
             visible: Visible {
-                is_visible: false, // TODO: Remember to set to true in shapesprite_maker!!!
+                is_visible: false,
                 is_transparent: true,
             },
             main_pass: MainPass,
             draw: Default::default(),
-            sprite: Default::default(),
+            sprite: Sprite {
+                size: Vec2::new(1.0, 1.0),
+                ..Default::default()
+            },
             material: Default::default(),
             transform: Default::default(),
             global_transform: Default::default(),

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -17,14 +17,16 @@ use lyon_tessellation::{path::Path, FillOptions};
 
 use crate::plugin::TessellationMode;
 
-// FIXME: Make a Processed(bool) component to prevent creating meshes
-// indefinitely.
+/// Component that marks a [`ShapeBundle`] as completed or not.
+pub struct Processed(pub bool);
+
 /// A [`Bundle`] that represents a shape.
 #[allow(missing_docs)]
 #[derive(Bundle)]
 pub struct ShapeBundle {
     pub path: Path,
     pub mode: TessellationMode,
+    pub processed: Processed,
     pub sprite: Sprite,
     pub mesh: Handle<Mesh>,
     pub material: Handle<ColorMaterial>,
@@ -41,6 +43,7 @@ impl Default for ShapeBundle {
         Self {
             path: Path::new(),
             mode: TessellationMode::Fill(FillOptions::default()),
+            processed: Processed(false),
             mesh: QUAD_HANDLE.typed(),
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
                 SPRITE_PIPELINE_HANDLE.typed(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! Draw 2D shapes in Bevy.
 //!
-//! This crate provides a Bevy [plugin] to draw shapes with minimum boilerplate.
+//! This crate provides a Bevy [plugin] to easily draw shapes.
 //! Some shapes are provided for convenience, however you can extend the
 //! functionality of this crate by implementing the
 //! [`ShapeSprite`](plugin::ShapeSprite) trait by your own.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
     clippy::cargo
 )]
 
-use bevy_render::{
+use bevy::render::{
     mesh::{Indices, Mesh},
     pipeline::PrimitiveTopology,
 };
@@ -31,6 +31,7 @@ use lyon_tessellation::{
 };
 
 pub mod conversions;
+pub mod entity;
 pub mod path;
 pub mod plugin;
 pub mod shapes;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ pub mod shapes;
 pub mod prelude {
     pub use crate::{
         path::PathBuilder,
-        plugin::{draw_path, Multishape, ShapePlugin, ShapeSprite, TessellationMode, Tessellator},
+        plugin::{draw_path, Multishape, ShapePlugin, ShapeSprite, TessellationMode},
         shapes,
     };
     pub use lyon_tessellation::{

--- a/src/path.rs
+++ b/src/path.rs
@@ -11,7 +11,7 @@ use lyon_tessellation::{
 pub struct PathBuilder(WithSvg<Builder>);
 
 impl PathBuilder {
-    /// Returns a new, empty `PathBuilder`
+    /// Returns a new, empty `PathBuilder`.
     pub fn new() -> Self {
         Self(Builder::new().with_svg())
     }

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,7 +1,7 @@
 //! Interface to build custom paths.
 
 use crate::conversions::Convert;
-use bevy_math::Vec2;
+use bevy::math::Vec2;
 use lyon_tessellation::{
     geom::Angle,
     path::{builder::WithSvg, path::Builder, EndpointId, Path},

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -11,7 +11,11 @@
 //! that creates a mesh for each entity that has been spawned as a
 //! `ShapeBundle`.
 
-use crate::{build_mesh, entity::ShapeBundle, Buffers, VertexConstructor};
+use crate::{
+    build_mesh,
+    entity::{Processed, ShapeBundle},
+    Buffers, VertexConstructor,
+};
 use bevy::{
     app::{stage, AppBuilder, Plugin},
     asset::{Assets, Handle},
@@ -65,9 +69,19 @@ fn shapesprite_maker(
     mut meshes: ResMut<Assets<Mesh>>,
     mut fill_tess: ResMut<FillTessellator>,
     mut stroke_tess: ResMut<StrokeTessellator>,
-    mut query: Query<(&TessellationMode, &Path, &mut Handle<Mesh>, &mut Visible)>,
+    mut query: Query<(
+        &TessellationMode,
+        &Path,
+        &mut Handle<Mesh>,
+        &mut Visible,
+        &mut Processed,
+    )>,
 ) {
-    for (tess_mode, path, mut mesh, mut visible) in query.iter_mut() {
+    for (tess_mode, path, mut mesh, mut visible, mut processed) in query.iter_mut() {
+        if processed.0 {
+            continue;
+        }
+
         let mut buffers = Buffers::new();
 
         match tess_mode {
@@ -93,6 +107,7 @@ fn shapesprite_maker(
 
         *mesh = meshes.add(build_mesh(&buffers));
         visible.is_visible = true;
+        *processed = Processed(true);
     }
 }
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -43,33 +43,16 @@ pub enum TessellationMode {
     Stroke(StrokeOptions),
 }
 
-/// A couple of `lyon` fill and stroke tessellators.
-pub struct Tessellator {
-    /// Tessellates the entire shape defined by the lyon [`Path`].
-    pub fill: FillTessellator,
-    /// Tessellates the border of the shape defined by the lyon [`Path`].
-    pub stroke: StrokeTessellator,
-}
-
-impl Tessellator {
-    /// Creates a new `Tessellator` data structure, containing the two types of
-    /// Lyon tessellator.
-    pub fn new() -> Self {
-        Self {
-            fill: FillTessellator::new(),
-            stroke: StrokeTessellator::new(),
-        }
-    }
-}
-
 /// A plugin that provides resources and a system to draw shapes in Bevy with
 /// less boilerplate.
 pub struct ShapePlugin;
 
 impl Plugin for ShapePlugin {
     fn build(&self, app: &mut AppBuilder) {
-        let tessellator = Tessellator::new();
-        app.add_resource(tessellator)
+        let fill_tess = FillTessellator::new();
+        let stroke_tess = StrokeTessellator::new();
+        app.add_resource(fill_tess)
+            .add_resource(stroke_tess)
             .add_stage_after(
                 stage::UPDATE,
                 shape_plugin_stage::SHAPE,
@@ -99,7 +82,8 @@ pub struct ShapeDescriptor {
 fn shapesprite_maker(
     commands: &mut Commands,
     mut meshes: ResMut<Assets<Mesh>>,
-    mut tessellator: ResMut<Tessellator>,
+    mut fill_tess: ResMut<FillTessellator>,
+    mut stroke_tess: ResMut<StrokeTessellator>,
     query: Query<(Entity, &ShapeDescriptor)>,
 ) {
     for (entity, shape_descriptor) in query.iter() {
@@ -107,8 +91,7 @@ fn shapesprite_maker(
 
         match shape_descriptor.mode {
             TessellationMode::Fill(ref options) => {
-                tessellator
-                    .fill
+                fill_tess
                     .tessellate_path(
                         &shape_descriptor.path,
                         options,
@@ -117,8 +100,7 @@ fn shapesprite_maker(
                     .unwrap();
             }
             TessellationMode::Stroke(ref options) => {
-                tessellator
-                    .stroke
+                stroke_tess
                     .tessellate_path(
                         &shape_descriptor.path,
                         options,

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -15,13 +15,15 @@
 //! `ShapeDescriptor` component.
 
 use crate::{build_mesh, Buffers, VertexConstructor};
-use bevy_app::{stage, AppBuilder, Plugin};
-use bevy_asset::{Assets, Handle};
-use bevy_ecs::{Commands, Entity, IntoSystem, Query, ResMut, SystemStage};
-use bevy_math::Vec2;
-use bevy_render::mesh::Mesh;
-use bevy_sprite::{entity::SpriteBundle, ColorMaterial, Sprite};
-use bevy_transform::components::Transform;
+use bevy::{
+    app::{stage, AppBuilder, Plugin},
+    asset::{Assets, Handle},
+    ecs::{Commands, Entity, IntoSystem, Query, ResMut, SystemStage},
+    math::Vec2,
+    render::mesh::Mesh,
+    sprite::{entity::SpriteBundle, ColorMaterial, Sprite},
+    transform::components::Transform,
+};
 use lyon_tessellation::{
     path::{path::Builder, Path},
     BuffersBuilder, FillOptions, FillTessellator, StrokeOptions, StrokeTessellator,

--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -5,7 +5,7 @@
 //! the trait for your own shapes.
 
 use crate::{conversions::Convert, plugin::ShapeSprite};
-use bevy_math::Vec2;
+use bevy::math::Vec2;
 use lyon_tessellation::{
     math::{point, Angle, Point, Rect, Size},
     path::{path::Builder, traits::PathBuilder, Polygon as LyonPolygon, Winding},


### PR DESCRIPTION
### Removed:
- `Tessellator` struct. Redundant.

### Changed:
- `ShapeDescriptor` and `SpriteBundle` have been replaced by `ShapeBundle`.
