### PR TITLE
Order struct fields in shorthand construction

### DIFF
--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -412,7 +412,7 @@ impl Geometry for SvgPathShape {
                             Angle {
                                 radians: x_axis_rotation as f32,
                             },
-                            ArcFlags { sweep, large_arc },
+                            ArcFlags { large_arc, sweep },
                             get_point_after_offset(x, y, offset_x, offset_y),
                         );
                     } else {
@@ -421,7 +421,7 @@ impl Geometry for SvgPathShape {
                             Angle {
                                 radians: x_axis_rotation as f32,
                             },
-                            ArcFlags { sweep, large_arc },
+                            ArcFlags { large_arc, sweep },
                             get_corrected_relative_vector(x, y),
                         );
                     }


### PR DESCRIPTION
To fix clippy warnings.