### PR TITLE
Fix bevy ECS V2 breaking changes 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,3 @@ lyon_tessellation = "0.17"
 svgtypes = "0.5.0"
 [dev-dependencies]
 bevy = {git = "https://github.com/bevyengine/bevy", branch = "main"}
-# bevy_egui = "0.2"
-# bevy_rapier2d = "0.8"
-rand = "0.8"

--- a/examples/readme_example.rs
+++ b/examples/readme_example.rs
@@ -12,7 +12,7 @@ fn main() {
         .run();
 }
 
-fn setup(commands: &mut Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
+fn setup(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
     let circle = shapes::Circle {
         radius: 100.0,
         ..shapes::Circle::default()

--- a/examples/svg_path_shape_example.rs
+++ b/examples/svg_path_shape_example.rs
@@ -19,7 +19,7 @@ struct BuildingBundle {
     transform: Transform,
     global_transform: GlobalTransform,
 }
-fn startup_system(commands: &mut Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
+fn startup_system(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
     commands.spawn(OrthographicCameraBundle::new_2d());
 
     commands.spawn(BuildingBundle {

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -3,7 +3,7 @@
 use crate::utils::TessellationMode;
 use bevy::{
     asset::Handle,
-    ecs::Bundle,
+    ecs::bundle::Bundle,
     math::Vec2,
     render::{
         draw::{Draw, Visible},

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -1,6 +1,6 @@
 //! Custom Bevy [`Bundle`] for shapes.
 
-use crate::utils::TessellationMode;
+use crate::{render::SHAPE_PIPELINE_HANDLE, utils::TessellationMode};
 use bevy::{
     asset::Handle,
     ecs::bundle::Bundle,
@@ -11,7 +11,7 @@ use bevy::{
         pipeline::{RenderPipeline, RenderPipelines},
         render_graph::base::MainPass,
     },
-    sprite::{ColorMaterial, Sprite, QUAD_HANDLE, SPRITE_PIPELINE_HANDLE},
+    sprite::{ColorMaterial, Sprite, QUAD_HANDLE},
     transform::components::{GlobalTransform, Transform},
 };
 use lyon_tessellation::{path::Path, FillOptions};
@@ -45,7 +45,7 @@ impl Default for ShapeBundle {
             processed: Processed(false),
             mesh: QUAD_HANDLE.typed(),
             render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
-                SPRITE_PIPELINE_HANDLE.typed(),
+                SHAPE_PIPELINE_HANDLE.typed(),
             )]),
             visible: Visible {
                 is_visible: false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub mod entity;
 pub mod geometry;
 pub mod path;
 pub mod plugin;
+pub mod render;
 pub mod shapes;
 pub mod utils;
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -15,7 +15,10 @@ use crate::{entity::Processed, utils::TessellationMode};
 use bevy::{
     app::{AppBuilder, Plugin},
     asset::{Assets, Handle},
-    ecs::{IntoSystem, Query, ResMut, SystemStage},
+    ecs::{
+        schedule::SystemStage,
+        system::{IntoSystem, Query, ResMut},
+    },
     log::error,
     render::{
         draw::Visible,

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -93,6 +93,7 @@ impl Plugin for ShapePlugin {
                 stage::SHAPE,
                 SystemStage::parallel(),
             )
+            .add_startup_system(crate::render::add_shape_pipeline.system())
             .add_system_to_stage(stage::SHAPE, complete_shape_bundle.system());
     }
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1,0 +1,85 @@
+// TODO: Add docs and remove.
+#![allow(missing_docs)]
+
+use bevy::{
+    asset::{Assets, HandleUntyped},
+    ecs::system::ResMut,
+    reflect::TypeUuid,
+    render::{
+        pipeline::{
+            BlendFactor, BlendOperation, BlendState, ColorTargetState, ColorWrite, CompareFunction,
+            CullMode, DepthBiasState, DepthStencilState, FrontFace, PipelineDescriptor,
+            PolygonMode, PrimitiveState, PrimitiveTopology, StencilFaceState, StencilState,
+        },
+        shader::{Shader, ShaderStage, ShaderStages},
+        texture::TextureFormat,
+    },
+};
+
+#[allow(clippy::unreadable_literal)]
+pub const SHAPE_PIPELINE_HANDLE: HandleUntyped =
+    HandleUntyped::weak_from_u64(PipelineDescriptor::TYPE_UUID, 3868147544761532180);
+
+fn build_shape_pipeline(mut shaders: ResMut<Assets<Shader>>) -> PipelineDescriptor {
+    PipelineDescriptor {
+        depth_stencil: Some(DepthStencilState {
+            format: TextureFormat::Depth32Float,
+            depth_write_enabled: true,
+            depth_compare: CompareFunction::LessEqual,
+            stencil: StencilState {
+                front: StencilFaceState::IGNORE,
+                back: StencilFaceState::IGNORE,
+                read_mask: 0,
+                write_mask: 0,
+            },
+            bias: DepthBiasState {
+                constant: 0,
+                slope_scale: 0.0,
+                clamp: 0.0,
+            },
+            clamp_depth: false,
+        }),
+        color_target_states: vec![ColorTargetState {
+            format: TextureFormat::default(),
+            color_blend: BlendState {
+                src_factor: BlendFactor::SrcAlpha,
+                dst_factor: BlendFactor::OneMinusSrcAlpha,
+                operation: BlendOperation::Add,
+            },
+            alpha_blend: BlendState {
+                src_factor: BlendFactor::One,
+                dst_factor: BlendFactor::One,
+                operation: BlendOperation::Add,
+            },
+            write_mask: ColorWrite::ALL,
+        }],
+        primitive: PrimitiveState {
+            topology: PrimitiveTopology::TriangleList,
+            strip_index_format: None,
+            front_face: FrontFace::Cw,
+            cull_mode: CullMode::Back,
+            polygon_mode: PolygonMode::Fill,
+        },
+        ..PipelineDescriptor::new(ShaderStages {
+            vertex: shaders.add(Shader::from_glsl(
+                ShaderStage::Vertex,
+                include_str!("shape.vert"),
+            )),
+            fragment: Some(shaders.add(Shader::from_glsl(
+                ShaderStage::Fragment,
+                include_str!("shape.frag"),
+            ))),
+        })
+    }
+}
+
+pub mod node {
+    pub const SHAPE: &str = "bevy_prototype_lyon:shape";
+}
+
+pub(crate) fn add_shape_pipeline(
+    mut pipelines: ResMut<Assets<PipelineDescriptor>>,
+    shaders: ResMut<Assets<Shader>>,
+) {
+    pipelines.set_untracked(SHAPE_PIPELINE_HANDLE, build_shape_pipeline(shaders));
+}

--- a/src/render/shape.frag
+++ b/src/render/shape.frag
@@ -1,0 +1,24 @@
+#version 450
+
+layout(location = 0) in vec2 v_Uv;
+
+layout(location = 0) out vec4 o_Target;
+
+layout(set = 1, binding = 0) uniform ColorMaterial_color {
+    vec4 Color;
+};
+
+# ifdef COLORMATERIAL_TEXTURE 
+layout(set = 1, binding = 1) uniform texture2D ColorMaterial_texture;
+layout(set = 1, binding = 2) uniform sampler ColorMaterial_texture_sampler;
+# endif
+
+void main() {
+    vec4 color = Color;
+# ifdef COLORMATERIAL_TEXTURE
+    color *= texture(
+        sampler2D(ColorMaterial_texture, ColorMaterial_texture_sampler),
+        v_Uv);
+# endif
+    o_Target = color;
+}

--- a/src/render/shape.vert
+++ b/src/render/shape.vert
@@ -1,0 +1,26 @@
+#version 450
+
+layout(location = 0) in vec3 Vertex_Position;
+layout(location = 1) in vec3 Vertex_Normal;
+layout(location = 2) in vec2 Vertex_Uv;
+
+layout(location = 0) out vec2 v_Uv;
+
+layout(set = 0, binding = 0) uniform Camera {
+    mat4 ViewProj;
+};
+
+layout(set = 2, binding = 0) uniform Transform {
+    mat4 Model;
+};
+layout(set = 2, binding = 1) uniform Sprite {
+    vec2 size;
+    uint flip;
+};
+
+void main() {
+    vec2 uv = Vertex_Uv;
+    v_Uv = uv;
+    vec3 position = Vertex_Position * vec3(size, 1.0);
+    gl_Position = ViewProj * Model * vec4(position, 1.0);
+}

--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -84,7 +84,7 @@ impl Default for Circle {
     fn default() -> Self {
         Self {
             radius: 1.0,
-            center: Vec2::zero(),
+            center: Vec2::ZERO,
         }
     }
 }
@@ -105,8 +105,8 @@ pub struct Ellipse {
 impl Default for Ellipse {
     fn default() -> Self {
         Self {
-            radii: Vec2::one(),
-            center: Vec2::zero(),
+            radii: Vec2::ONE,
+            center: Vec2::ZERO,
         }
     }
 }
@@ -191,7 +191,7 @@ impl Default for RegularPolygon {
     fn default() -> Self {
         Self {
             sides: 3,
-            center: Vec2::zero(),
+            center: Vec2::ZERO,
             feature: RegularPolygonFeature::Radius(1.0),
         }
     }


### PR DESCRIPTION
I added a custom rendering pipeline for `ShapeBundle` in order to fix a backface culling incompatibility between lyon and the new Bevy sprite pipeline.