### PR TITLE
Prepare for Bevy 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 name = "bevy_prototype_lyon"
 readme = "README.md"
 repository = "https://github.com/Nilirad/bevy_prototype_lyon/"
-version = "0.2.0"
+version = "0.3.0"
 resolver = "2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,13 @@ name = "bevy_prototype_lyon"
 readme = "README.md"
 repository = "https://github.com/Nilirad/bevy_prototype_lyon/"
 version = "0.2.0"
+resolver = "2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = {git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false}
+bevy = {version = "0.5", default-features = false}
 lyon_tessellation = "0.17"
 svgtypes = "0.5.0"
 [dev-dependencies]
-bevy = {git = "https://github.com/bevyengine/bevy", branch = "main"}
+bevy = "0.5"

--- a/README.md
+++ b/README.md
@@ -44,26 +44,30 @@ use bevy_prototype_lyon::prelude::*;
 
 fn main() {
     App::build()
+        .insert_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
         .add_plugin(ShapePlugin)
         .add_startup_system(setup.system())
         .run();
 }
 
-fn setup(commands: &mut Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
-    let circle = shapes::Circle {
-        radius: 100.0,
-        ..shapes::Circle::default()
+fn setup(mut commands: Commands) {
+    let shape = shapes::RegularPolygon {
+        sides: 6,
+        feature: shapes::RegularPolygonFeature::Radius(200.0),
+        ..shapes::RegularPolygon::default()
     };
 
-    commands
-        .spawn(Camera2dBundle::default())
-        .spawn(GeometryBuilder::build_as(
-            &circle,
-            materials.add(ColorMaterial::color(Color::AQUAMARINE)),
-            TessellationMode::Fill(FillOptions::default()),
-            Transform::default(),
-        ));
+    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+    commands.spawn_bundle(GeometryBuilder::build_as(
+        &shape,
+        ShapeColors::outlined(Color::TEAL, Color::BLACK),
+        DrawMode::Outlined {
+            fill_options: FillOptions::default(),
+            outline_options: StrokeOptions::default().with_line_width(10.0),
+        },
+        Transform::default(),
+    ));
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Currently Bevy does not support drawing custom shapes in an easy way. This crate
 
 ### Changelog
 
+#### 0.3.0
+- Works with bevy 0.5
+
 #### 0.2.0
 - Complete API reworking
 - Regular polygon support


### PR DESCRIPTION
It seems like things are generally working with bevy 0.5.

This PR just points the dependencies at crates.io, updates the readme, and bumps `bevy_prototype_lyon`'s version.

I also opted into the new cargo dependency resolver.