### PR TITLE
Fix clippy namespace recursions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 // lints that need revisiting
 
 // TODO: Add lint and fix names
-#![allow(clippy::clippy::module_name_repetitions)]
+#![allow(clippy::module_name_repetitions)]
 
 // Could have many false positives. Uncomment if needed.
 //#![allow(clippy::must_use_candidate)]

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -166,7 +166,7 @@ fn complete_shape_bundle(
     }
 }
 
-#[allow(clippy::clippy::trivially_copy_pass_by_ref)] // lyon takes &FillOptions
+#[allow(clippy::trivially_copy_pass_by_ref)] // lyon takes &FillOptions
 fn fill(
     tess: &mut ResMut<FillTessellator>,
     path: &Path,
@@ -188,7 +188,7 @@ fn fill(
     }
 }
 
-#[allow(clippy::clippy::trivially_copy_pass_by_ref)] // lyon takes &StrokeOptions
+#[allow(clippy::trivially_copy_pass_by_ref)] // lyon takes &StrokeOptions
 fn stroke(
     tess: &mut ResMut<StrokeTessellator>,
     path: &Path,

--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -290,7 +290,7 @@ fn get_corrected_relative_vector(x: f64, y: f64) -> Vector {
     Vector::new(x as f32, get_y_in_bevy_orientation(y))
 }
 impl Geometry for SvgPathShape {
-    #[allow(clippy::clippy::too_many_lines)]
+    #[allow(clippy::too_many_lines)]
     fn add_geometry(&self, b: &mut Builder) {
         let builder = Builder::new();
         let mut svg_builder = WithSvg::new(builder);


### PR DESCRIPTION
There were many `clippy::clippy::lint` forms instead of the `clippy::lint` correct form. In previous versions this was accepted, but not anymore.
This pr fixes the attributes with the correct namespaces.