### PR TITLE
Make possible to spawn invisible shapes

### DIFF
--- a/src/entity.rs
+++ b/src/entity.rs
@@ -72,8 +72,8 @@ impl Default for ShapeBundle {
                 SHAPE_PIPELINE_HANDLE.typed(),
             )]),
             visible: Visible {
-                is_visible: false,
                 is_transparent: true,
+                ..Visible::default()
             },
             main_pass: MainPass,
             draw: Draw::default(),

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -22,7 +22,6 @@ use bevy::{
     log::error,
     render::{
         color::Color,
-        draw::Visible,
         mesh::{Indices, Mesh},
         pipeline::PrimitiveTopology,
     },
@@ -119,18 +118,9 @@ fn complete_shape_bundle_system(
     mut meshes: ResMut<Assets<Mesh>>,
     mut fill_tess: ResMut<FillTessellator>,
     mut stroke_tess: ResMut<StrokeTessellator>,
-    mut query: Query<
-        (
-            &DrawMode,
-            &Path,
-            &mut Handle<Mesh>,
-            &ShapeColors,
-            &mut Visible,
-        ),
-        Added<Path>,
-    >,
+    mut query: Query<(&DrawMode, &Path, &mut Handle<Mesh>, &ShapeColors), Added<Path>>,
 ) {
-    for (tess_mode, path, mut mesh, colors, mut visible) in query.iter_mut() {
+    for (tess_mode, path, mut mesh, colors) in query.iter_mut() {
         let mut buffers = VertexBuffers::new();
 
         match tess_mode {
@@ -162,7 +152,6 @@ fn complete_shape_bundle_system(
         }
 
         *mesh = meshes.add(build_mesh(&buffers));
-        visible.is_visible = true;
     }
 }
 


### PR DESCRIPTION
- Fixes #108 

## Example of working code

A shape initially invisible, becomes visible after 3 seconds.

```rust
use bevy::prelude::*;
use bevy_prototype_lyon::prelude::*;

struct Hook;

fn main() {
    App::new()
        .insert_resource(Msaa { samples: 8 })
        .add_plugins(DefaultPlugins)
        .add_plugin(ShapePlugin)
        .add_startup_system(setup_system)
        .add_system(make_shape_visible_system)
        .run();
}

fn setup_system(mut commands: Commands) {
    let shape = shapes::RegularPolygon {
        sides: 6,
        feature: shapes::RegularPolygonFeature::Radius(200.0),
        ..shapes::RegularPolygon::default()
    };

    commands.spawn_bundle(OrthographicCameraBundle::new_2d());

    let mut shape_bundle = GeometryBuilder::build_as(
        &shape,
        ShapeColors::outlined(Color::TEAL, Color::BLACK),
        DrawMode::Outlined {
            fill_options: FillOptions::default(),
            outline_options: StrokeOptions::default().with_line_width(10.0),
        },
        Transform::default(),
    );
    shape_bundle.visible.is_visible = false;

    commands.spawn_bundle(shape_bundle).insert(Hook);
}

fn make_shape_visible_system(
    mut commands: Commands,
    mut query: Query<(Entity, &mut Visible), With<Hook>>,
    time: Res<Time>,
) {
    if time.seconds_since_startup() >= 3.0 {
        for (entity, mut visible) in query.iter_mut() {
            visible.is_visible = true;
            commands.entity(entity).remove::<Hook>();
        }
    }
}
```