### PR TITLE
Fix colors not matching bevy sprites

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -66,12 +66,7 @@ impl FillVertexConstructor<Vertex> for VertexConstructor {
     fn new_vertex(&mut self, vertex: FillVertex) -> Vertex {
         Vertex {
             position: [vertex.position().x, vertex.position().y],
-            color: [
-                self.color.r(),
-                self.color.g(),
-                self.color.b(),
-                self.color.a(),
-            ],
+            color: self.color.as_linear_rgba_f32(),
         }
     }
 }
@@ -81,12 +76,7 @@ impl StrokeVertexConstructor<Vertex> for VertexConstructor {
     fn new_vertex(&mut self, vertex: StrokeVertex) -> Vertex {
         Vertex {
             position: [vertex.position().x, vertex.position().y],
-            color: [
-                self.color.r(),
-                self.color.g(),
-                self.color.b(),
-                self.color.a(),
-            ],
+            color: self.color.as_linear_rgba_f32(),
         }
     }
 }


### PR DESCRIPTION
Fixes #107

I saw this mentioned in discord by another user and figured I'd actually look into it.

Should work just as well for bevy 0.5 as main, but I am not sure what your process is for doing minor releases.

This seems like the correct thing to do based on how colors seem to get treated for bevy's sprite pipeline, but I'm not very familiar with bevy's rendering code. 

So if this seems wrong or if merging complicates releasing a fix for 0.3, feel free to close and reimplement (or not)