### PR TITLE
UI shapes

### DIFF
--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -1,0 +1,308 @@
+//! Shows how to use shapes for the UI camera.
+
+use bevy::prelude::*;
+use bevy_prototype_lyon::{
+    prelude::*,
+    shapes::{RegularPolygon, RegularPolygonFeature},
+};
+
+use lyon_tessellation::path::{path::Builder, Path};
+
+// Credits: https://commons.wikimedia.org/wiki/File:Octicons-heart.svg
+const SVG_HEART: &str = "M19.2 43.2c19.95-15.7 19.2-21.25 19.2-25.6s-3.6-9.6-9.6-9.6s-9.6 6.4-9.6 6.4s-3.6-6.4-9.6-6.4s-9.6 5.25-9.6 9.6s-.75 9.9 19.2 25.6z";
+
+struct Player;
+struct Health(f32);
+struct Lives(i32);
+struct DamageCooldown {
+    never_damaged: bool,
+    timer: Timer,
+}
+struct HealthBar;
+struct Heart1;
+struct Heart2;
+struct Heart3;
+
+fn main() {
+    // TODO: gameplay and ui system sets.
+    App::new()
+        .insert_resource(Msaa { samples: 8 })
+        .add_plugins(DefaultPlugins)
+        .add_plugin(ShapePlugin)
+        .add_startup_system(setup_ui_system)
+        .add_startup_system(setup_gameplay_system)
+        .add_system(move_player_system)
+        .add_system(damage_player_system)
+        .add_system(update_health_bar_system)
+        .add_system(reset_dead_player_system)
+        .add_system(update_hearts_system)
+        .run();
+}
+
+// TODO: Add back third dimension for z-ordering. (Edit vertex constructors and shaders.)
+
+fn setup_ui_system(mut commands: Commands) {
+    commands.spawn_bundle(UiCameraBundle::default());
+
+    /* let hp_bar_background = GeometryBuilder::build_ui_as(
+        &shapes::Rectangle {
+            width: 310.0,
+            height: 50.0,
+            origin: shapes::RectangleOrigin::TopLeft,
+        },
+        ShapeColors::new(Color::BLACK),
+        DrawMode::Fill(FillOptions::default()),
+        Style {
+            position_type: PositionType::Absolute,
+            position: Rect {
+                left: Val::Px(20.0),
+                right: Val::Auto,
+                top: Val::Px(20.0),
+                bottom: Val::Auto,
+            },
+            ..Default::default()
+        },
+        0.0,
+    ); */
+
+    let hp_bar_foreground = GeometryBuilder::build_ui_as(
+        &shapes::Rectangle {
+            width: 300.0,
+            height: 40.0,
+            origin: shapes::RectangleOrigin::TopLeft,
+        },
+        ShapeColors::new(Color::GREEN),
+        DrawMode::Fill(FillOptions::default()),
+        Style {
+            position_type: PositionType::Absolute,
+            position: Rect {
+                left: Val::Px(25.0),
+                right: Val::Auto,
+                top: Val::Px(25.0),
+                bottom: Val::Auto,
+            },
+            ..Default::default()
+        },
+        -1.0,
+    );
+
+    let heart_shape = shapes::SvgPathShape {
+        svg_doc_size_in_px: Vec2::new(0.0, 0.0),
+        svg_path_string: SVG_HEART.to_owned(),
+    };
+
+    let heart1 = GeometryBuilder::build_ui_as(
+        &heart_shape,
+        ShapeColors::outlined(Color::RED, Color::BLACK),
+        DrawMode::Outlined {
+            fill_options: FillOptions::default(),
+            outline_options: StrokeOptions::default().with_line_width(5.0),
+        },
+        Style {
+            position_type: PositionType::Absolute,
+            position: Rect {
+                left: Val::Px(30.0),
+                right: Val::Auto,
+                top: Val::Px(80.0),
+                bottom: Val::Auto,
+            },
+            ..Default::default()
+        },
+        -1.0,
+    );
+
+    let heart2 = GeometryBuilder::build_ui_as(
+        &heart_shape,
+        ShapeColors::outlined(Color::RED, Color::BLACK),
+        DrawMode::Outlined {
+            fill_options: FillOptions::default(),
+            outline_options: StrokeOptions::default().with_line_width(5.0),
+        },
+        Style {
+            position_type: PositionType::Absolute,
+            position: Rect {
+                left: Val::Px(80.0),
+                right: Val::Auto,
+                top: Val::Px(80.0),
+                bottom: Val::Auto,
+            },
+            ..Default::default()
+        },
+        -1.0,
+    );
+
+    let heart3 = GeometryBuilder::build_ui_as(
+        &heart_shape,
+        ShapeColors::outlined(Color::RED, Color::BLACK),
+        DrawMode::Outlined {
+            fill_options: FillOptions::default(),
+            outline_options: StrokeOptions::default().with_line_width(5.0),
+        },
+        Style {
+            position_type: PositionType::Absolute,
+            position: Rect {
+                left: Val::Px(130.0),
+                right: Val::Auto,
+                top: Val::Px(80.0),
+                bottom: Val::Auto,
+            },
+            ..Default::default()
+        },
+        -1.0,
+    );
+
+    commands.spawn_bundle(hp_bar_foreground).insert(HealthBar);
+    //commands.spawn_bundle(hp_bar_background);
+    commands.spawn_bundle(heart1).insert(Heart1);
+    commands.spawn_bundle(heart2).insert(Heart2);
+    commands.spawn_bundle(heart3).insert(Heart3);
+}
+
+fn setup_gameplay_system(mut commands: Commands) {
+    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+
+    let lava_pool = GeometryBuilder::build_as(
+        &shapes::Rectangle {
+            width: 200.0,
+            height: 200.0,
+            ..shapes::Rectangle::default()
+        },
+        ShapeColors::outlined(Color::ORANGE, Color::BLACK),
+        DrawMode::Outlined {
+            fill_options: FillOptions::default(),
+            outline_options: StrokeOptions::default().with_line_width(5.0),
+        },
+        Transform::default(),
+    );
+
+    let player = GeometryBuilder::build_as(
+        &RegularPolygon {
+            sides: 3,
+            feature: RegularPolygonFeature::Radius(30.0),
+            ..RegularPolygon::default()
+        },
+        ShapeColors::outlined(Color::CYAN, Color::BLACK),
+        DrawMode::Outlined {
+            fill_options: FillOptions::default(),
+            outline_options: StrokeOptions::default().with_line_width(3.0),
+        },
+        Transform::from_xyz(-300.0, 0.0, 0.0),
+    );
+
+    commands.spawn_bundle(lava_pool);
+    commands
+        .spawn_bundle(player)
+        .insert(Player)
+        .insert(Health(10.0))
+        .insert(Lives(3))
+        .insert(DamageCooldown {
+            never_damaged: true,
+            timer: Timer::from_seconds(0.5, false),
+        });
+}
+
+fn move_player_system(mut query: Query<&mut Transform, With<Player>>) {
+    let mut transform = query.single_mut().unwrap();
+    transform.translation.x = (transform.translation.x + 5.0).min(0.0);
+}
+
+fn damage_player_system(
+    mut query: Query<(&mut Health, &mut DamageCooldown, &Transform), With<Player>>,
+    time: Res<Time>,
+) {
+    let (mut health, mut damage_cooldown, transform) = query.single_mut().unwrap();
+    let pos_x = transform.translation.x;
+
+    if !damage_cooldown.never_damaged {
+        damage_cooldown.timer.tick(time.delta());
+    }
+
+    if pos_x > -100.0 {
+        if damage_cooldown.never_damaged {
+            damage_cooldown.never_damaged = false;
+            health.0 = (health.0 - 3.0).max(0.0);
+        } else if damage_cooldown.timer.finished() {
+            health.0 = (health.0 - 3.0).max(0.0);
+            damage_cooldown.timer.reset();
+        }
+    }
+}
+
+fn update_health_bar_system(
+    mut health_bar_query: Query<&mut Path, With<HealthBar>>,
+    player_query: Query<&Health, With<Player>>,
+) {
+    let player_health = player_query.single().unwrap().0;
+
+    let mut b = Builder::new();
+    let newrect = shapes::Rectangle {
+        width: player_health * 30.0,
+        height: 40.0,
+        origin: shapes::RectangleOrigin::TopLeft,
+    };
+    newrect.add_geometry(&mut b);
+
+    let mut health_bar = health_bar_query.single_mut().unwrap();
+    *health_bar = b.build();
+}
+
+fn update_hearts_system(
+    mut heart_1_query: Query<
+        (&mut ShapeColors, &mut DrawMode),
+        (With<Heart1>, Without<Heart2>, Without<Heart3>),
+    >,
+    mut heart_2_query: Query<
+        (&mut ShapeColors, &mut DrawMode),
+        (With<Heart2>, Without<Heart1>, Without<Heart3>),
+    >,
+    mut heart_3_query: Query<
+        (&mut ShapeColors, &mut DrawMode),
+        (With<Heart3>, Without<Heart1>, Without<Heart2>),
+    >,
+    player_query: Query<&Lives, With<Player>>,
+) {
+    let player_lives = player_query.single().unwrap().0;
+    let heart_1_components = heart_1_query.single_mut().unwrap();
+    let heart_2_components = heart_2_query.single_mut().unwrap();
+    let heart_3_components = heart_3_query.single_mut().unwrap();
+
+    set_heart(heart_1_components, player_lives >= 1);
+    set_heart(heart_2_components, player_lives >= 2);
+    set_heart(heart_3_components, player_lives >= 3);
+}
+
+fn set_heart(heart_components: (Mut<ShapeColors>, Mut<DrawMode>), filled: bool) {
+    let (mut shape_colors, mut draw_mode) = heart_components;
+
+    if filled {
+        *shape_colors = ShapeColors::outlined(Color::RED, Color::BLACK);
+        *draw_mode = DrawMode::Outlined {
+            fill_options: FillOptions::default(),
+            outline_options: StrokeOptions::default().with_line_width(5.0),
+        }
+    } else {
+        *shape_colors = ShapeColors::new(Color::BLACK);
+        *draw_mode = DrawMode::Fill(FillOptions::default());
+    }
+}
+
+fn reset_dead_player_system(
+    mut query: Query<(&mut Health, &mut Lives, &mut Transform, &mut DamageCooldown), With<Player>>,
+) {
+    let (mut health, mut lives, mut transform, mut damage_cooldown) = query.single_mut().unwrap();
+
+    if health.0 <= 0.0 {
+        lives.0 -= 1;
+        if lives.0 > 0 {
+            health.0 = 10.0;
+            transform.translation.x = -300.0;
+            *damage_cooldown = DamageCooldown {
+                never_damaged: true,
+                timer: Timer::from_seconds(0.5, false),
+            };
+        } else {
+            // TODO: Game over.
+            println!("Game over");
+        }
+    }
+}

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -1,14 +1,15 @@
 //! Shows how to use shapes for the UI camera.
 
-use std::f32::consts::{FRAC_PI_2, PI};
-use std::time::Duration;
+use std::{
+    f32::consts::{FRAC_PI_2, PI},
+    time::Duration,
+};
 
 use bevy::prelude::*;
 use bevy_prototype_lyon::{
     prelude::*,
     shapes::{RegularPolygon, RegularPolygonFeature},
 };
-
 use lyon_tessellation::path::{path::Builder, Path};
 
 // TODO: Use states to reset player data in initialization or after death?
@@ -251,17 +252,15 @@ fn damage_character_system(
 
     let mut damage_applied = false;
 
-    if transform.translation.x > DAMAGE_TRESHOLD_X_POSITION {
-        if damage_cooldown.0.finished() {
-            damage_cooldown.0.reset();
-            let initial_health = health.0;
-            health.0 -= calculate_damage(health.0, DAMAGE_AMOUNT);
-            health_changed_event_writer.send(HealthChangedEvent {
-                from: initial_health,
-                to: health.0,
-            });
-            damage_applied = true;
-        }
+    if transform.translation.x > DAMAGE_TRESHOLD_X_POSITION && damage_cooldown.0.finished() {
+        damage_cooldown.0.reset();
+        let initial_health = health.0;
+        health.0 -= calculate_damage(health.0, DAMAGE_AMOUNT);
+        health_changed_event_writer.send(HealthChangedEvent {
+            from: initial_health,
+            to: health.0,
+        });
+        damage_applied = true;
     }
 
     if damage_applied {
@@ -327,10 +326,6 @@ fn update_hearts_system(
 fn set_heart(colors: &mut ShapeColors, draw_mode: &mut DrawMode, timer: &mut Timer, filled: bool) {
     if filled {
         *colors = ShapeColors::outlined(Color::RED, Color::BLACK);
-        *draw_mode = DrawMode::Outlined {
-            fill_options: FillOptions::default(),
-            outline_options: StrokeOptions::default().with_line_width(5.0),
-        }
     } else {
         if timer.paused() {
             timer.unpause();
@@ -338,17 +333,14 @@ fn set_heart(colors: &mut ShapeColors, draw_mode: &mut DrawMode, timer: &mut Tim
 
         if timer.finished() {
             *colors = ShapeColors::new(Color::BLACK);
-            *draw_mode = DrawMode::Outlined {
-                fill_options: FillOptions::default(),
-                outline_options: StrokeOptions::default().with_line_width(5.0),
-            }
         } else {
             *colors = ShapeColors::outlined(Color::WHITE, Color::BLACK);
-            *draw_mode = DrawMode::Outlined {
-                fill_options: FillOptions::default(),
-                outline_options: StrokeOptions::default().with_line_width(5.0),
-            }
         }
+    }
+
+    *draw_mode = DrawMode::Outlined {
+        fill_options: FillOptions::default(),
+        outline_options: StrokeOptions::default().with_line_width(5.0),
     }
 }
 

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -8,8 +8,6 @@ use bevy_prototype_lyon::{
 
 use lyon_tessellation::path::{path::Builder, Path};
 
-// TODO: Death animation
-
 // TODO: Dedicated system for timers?
 // TODO: Refactor keeping in mind character states?
 
@@ -84,8 +82,8 @@ fn main() {
                         .label("update_health_bar"),
                 )
                 .with_system(update_hearts_system.after("update_health_bar"))
-                .with_system(damage_animation_system)
-                .with_system(character_death_animation_system),
+                .with_system(damage_animation_system.label("damage_animation"))
+                .with_system(character_death_animation_system.after("damage_animation")),
         )
         .run();
 }
@@ -474,8 +472,6 @@ fn damage_animation_system(
     *shape_colors = ShapeColors::outlined(Color::rgb(red, green_blue, green_blue), Color::BLACK);
 }
 
-// TODO: Sometimes death animation doesn't work. Timers are working correctly. May it be
-// a change detection issue?
 fn character_death_animation_system(
     mut query: Query<(&mut Transform, &mut ShapeColors, &DeathAnimationTimer), With<Character>>,
 ) {

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -279,7 +279,7 @@ fn setup_gameplay_system(mut commands: Commands) {
 }
 
 fn move_character_system(mut query: Query<&mut Transform, With<Character>>) {
-    let mut transform = query.single_mut().unwrap();
+    let mut transform = query.single_mut();
     transform.translation.x = (transform.translation.x + CHARACHTER_TICK_X_DISPLACEMENT).min(0.0);
 }
 
@@ -288,7 +288,7 @@ fn damage_character_system(
     time: Res<Time>,
     mut health_change_event_writer: EventWriter<HealthChangeEvent>,
 ) {
-    let (mut health, mut damage_cooldown, transform) = query.single_mut().unwrap();
+    let (mut health, mut damage_cooldown, transform) = query.single_mut();
     let pos_x = transform.translation.x;
 
     if !damage_cooldown.never_damaged {
@@ -325,7 +325,7 @@ fn calculate_damage(cur_health: f32, desired_damage: f32) -> f32 {
 }
 
 fn update_health_bar_system(mut health_bar_query: Query<(&mut Path, &Animation), With<HealthBar>>) {
-    let (mut path, animation) = health_bar_query.single_mut().unwrap();
+    let (mut path, animation) = health_bar_query.single_mut();
 
     let animation_progress = animation.timer.percent();
     let animated_health_value = animation.initial_value
@@ -347,7 +347,7 @@ fn update_hearts_system(
     character_query: Query<&Lives, With<Character>>,
     time: Res<Time>,
 ) {
-    let character_lives = character_query.single().unwrap().0;
+    let character_lives = character_query.single().0;
     for (mut colors, mut draw_mode, heart, mut timer) in hearts_query.iter_mut() {
         timer.tick(time.delta());
         set_heart(
@@ -403,7 +403,7 @@ fn handle_character_death_system(
     time: Res<Time>,
 ) {
     let (mut health, mut lives, mut transform, mut damage_cooldown, mut death_animation_timer) =
-        query.single_mut().unwrap();
+        query.single_mut();
 
     if health.0 <= 0.0 {
         death_animation_timer.0.tick(time.delta());
@@ -436,7 +436,7 @@ fn animate_hp_bar_system(
     mut query: Query<&mut Animation, With<HealthBar>>,
     time: Res<Time>,
 ) {
-    let mut animation = query.single_mut().unwrap();
+    let mut animation = query.single_mut();
     animation.timer.tick(time.delta());
 
     for health_change in health_change_event_reader.iter() {
@@ -453,7 +453,7 @@ fn damage_animation_system(
     mut query: Query<(&mut Animation, &mut Transform, &mut ShapeColors), With<Character>>,
     time: Res<Time>,
 ) {
-    let (mut animation, mut transform, mut shape_colors) = query.single_mut().unwrap();
+    let (mut animation, mut transform, mut shape_colors) = query.single_mut();
     animation.timer.tick(time.delta());
     for health_change in health_change_event_reader.iter() {
         if health_change.to < health_change.from && health_change.to != 0.0 {
@@ -475,7 +475,7 @@ fn damage_animation_system(
 fn character_death_animation_system(
     mut query: Query<(&mut Transform, &mut ShapeColors, &DeathAnimationTimer), With<Character>>,
 ) {
-    let (mut transform, mut shape_colors, death_animation_timer) = query.single_mut().unwrap();
+    let (mut transform, mut shape_colors, death_animation_timer) = query.single_mut();
     let animation_progress = death_animation_timer.0.percent();
 
     if !death_animation_timer.0.paused() {

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -11,7 +11,6 @@ use bevy_prototype_lyon::{
 
 use lyon_tessellation::path::{path::Builder, Path};
 
-// TODO: Bundle spawning of hearts
 // TODO: Refactor keeping in mind character states?
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
@@ -138,63 +137,6 @@ fn setup_ui_system(mut commands: Commands) {
         svg_path_string: SVG_HEART.to_owned(),
     };
 
-    let heart1 = GeometryBuilder::build_ui_as(
-        &heart_shape,
-        ShapeColors::outlined(Color::RED, Color::BLACK),
-        DrawMode::Outlined {
-            fill_options: FillOptions::default(),
-            outline_options: StrokeOptions::default().with_line_width(5.0),
-        },
-        Style {
-            position_type: PositionType::Absolute,
-            position: Rect {
-                left: Val::Px(30.0),
-                right: Val::Auto,
-                top: Val::Px(80.0),
-                bottom: Val::Auto,
-            },
-            ..Default::default()
-        },
-    );
-
-    let heart2 = GeometryBuilder::build_ui_as(
-        &heart_shape,
-        ShapeColors::outlined(Color::RED, Color::BLACK),
-        DrawMode::Outlined {
-            fill_options: FillOptions::default(),
-            outline_options: StrokeOptions::default().with_line_width(5.0),
-        },
-        Style {
-            position_type: PositionType::Absolute,
-            position: Rect {
-                left: Val::Px(80.0),
-                right: Val::Auto,
-                top: Val::Px(80.0),
-                bottom: Val::Auto,
-            },
-            ..Default::default()
-        },
-    );
-
-    let heart3 = GeometryBuilder::build_ui_as(
-        &heart_shape,
-        ShapeColors::outlined(Color::RED, Color::BLACK),
-        DrawMode::Outlined {
-            fill_options: FillOptions::default(),
-            outline_options: StrokeOptions::default().with_line_width(5.0),
-        },
-        Style {
-            position_type: PositionType::Absolute,
-            position: Rect {
-                left: Val::Px(130.0),
-                right: Val::Auto,
-                top: Val::Px(80.0),
-                bottom: Val::Auto,
-            },
-            ..Default::default()
-        },
-    );
-
     commands
         .spawn_bundle(hp_bar_background)
         .with_children(|parent| {
@@ -211,18 +153,32 @@ fn setup_ui_system(mut commands: Commands) {
     let mut life_lost_timer = Timer::new(HEART_LOST_ANIMATION_TIME, false);
     life_lost_timer.pause();
 
-    commands
-        .spawn_bundle(heart1)
-        .insert(Heart(1))
-        .insert(life_lost_timer.clone());
-    commands
-        .spawn_bundle(heart2)
-        .insert(Heart(2))
-        .insert(life_lost_timer.clone());
-    commands
-        .spawn_bundle(heart3)
-        .insert(Heart(3))
-        .insert(life_lost_timer.clone());
+    for i in 1..=3 {
+        let offset = 50.0 * (i - 1) as f32;
+        let heart = GeometryBuilder::build_ui_as(
+            &heart_shape,
+            ShapeColors::outlined(Color::RED, Color::BLACK),
+            DrawMode::Outlined {
+                fill_options: FillOptions::default(),
+                outline_options: StrokeOptions::default().with_line_width(5.0),
+            },
+            Style {
+                position_type: PositionType::Absolute,
+                position: Rect {
+                    left: Val::Px(30.0 + offset),
+                    right: Val::Auto,
+                    top: Val::Px(80.0),
+                    bottom: Val::Auto,
+                },
+                ..Default::default()
+            },
+        );
+
+        commands
+            .spawn_bundle(heart)
+            .insert(Heart(i))
+            .insert(life_lost_timer.clone());
+    }
 }
 
 fn setup_gameplay_system(mut commands: Commands) {

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -70,9 +70,9 @@ fn main() {
         .add_system_set(
             SystemSet::on_update(GameState::Playing)
                 .label("gameplay")
-                .with_system(move_player_system)
-                .with_system(damage_player_system)
-                .with_system(handle_player_death_system),
+                .with_system(move_character_system)
+                .with_system(damage_character_system)
+                .with_system(handle_character_death_system),
         )
         .add_system_set(
             SystemSet::new()
@@ -280,12 +280,12 @@ fn setup_gameplay_system(mut commands: Commands) {
         .insert(DeathAnimationTimer(death_animation_timer));
 }
 
-fn move_player_system(mut query: Query<&mut Transform, With<Character>>) {
+fn move_character_system(mut query: Query<&mut Transform, With<Character>>) {
     let mut transform = query.single_mut().unwrap();
     transform.translation.x = (transform.translation.x + CHARACHTER_TICK_X_DISPLACEMENT).min(0.0);
 }
 
-fn damage_player_system(
+fn damage_character_system(
     mut query: Query<(&mut Health, &mut DamageCooldown, &Transform), With<Character>>,
     time: Res<Time>,
     mut health_change_event_writer: EventWriter<HealthChangeEvent>,
@@ -346,17 +346,17 @@ fn update_health_bar_system(mut health_bar_query: Query<(&mut Path, &Animation),
 
 fn update_hearts_system(
     mut hearts_query: Query<(&mut ShapeColors, &mut DrawMode, &Heart, &mut Timer)>,
-    player_query: Query<&Lives, With<Character>>,
+    character_query: Query<&Lives, With<Character>>,
     time: Res<Time>,
 ) {
-    let player_lives = player_query.single().unwrap().0;
+    let character_lives = character_query.single().unwrap().0;
     for (mut colors, mut draw_mode, heart, mut timer) in hearts_query.iter_mut() {
         timer.tick(time.delta());
         set_heart(
             &mut colors,
             &mut draw_mode,
             &mut timer,
-            player_lives >= heart.0,
+            character_lives >= heart.0,
         );
     }
 }
@@ -389,7 +389,7 @@ fn set_heart(colors: &mut ShapeColors, draw_mode: &mut DrawMode, timer: &mut Tim
     }
 }
 
-fn handle_player_death_system(
+fn handle_character_death_system(
     mut query: Query<
         (
             &mut Health,

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -12,10 +12,14 @@ use bevy::{
     },
     sprite::QUAD_HANDLE,
     transform::components::{GlobalTransform, Transform},
+    ui::{Node, Style},
 };
 use lyon_tessellation::{path::Path, FillOptions};
 
-use crate::{render::SHAPE_PIPELINE_HANDLE, utils::DrawMode};
+use crate::{
+    render::{SHAPE_PIPELINE_HANDLE, UI_SHAPE_PIPELINE_HANDLE},
+    utils::DrawMode,
+};
 
 /// The colors assigned to a shape.
 pub struct ShapeColors {
@@ -76,6 +80,49 @@ impl Default for ShapeBundle {
                 ..Visible::default()
             },
             main_pass: MainPass,
+            draw: Draw::default(),
+            colors: ShapeColors {
+                main: Color::WHITE,
+                outline: Color::BLACK,
+            },
+            transform: Transform::default(),
+            global_transform: GlobalTransform::default(),
+        }
+    }
+}
+
+/// A Bevy `Bundle` to represent a shape visible by a UI camera.
+#[allow(missing_docs)]
+#[derive(Bundle)]
+pub struct UiShapeBundle {
+    pub node: Node,
+    pub style: Style,
+    pub path: Path,
+    pub mode: DrawMode,
+    pub mesh: Handle<Mesh>,
+    pub colors: ShapeColors,
+    pub draw: Draw,
+    pub visible: Visible,
+    pub render_pipelines: RenderPipelines,
+    pub transform: Transform,
+    pub global_transform: GlobalTransform,
+}
+
+impl Default for UiShapeBundle {
+    fn default() -> Self {
+        Self {
+            node: Node::default(),
+            style: Style::default(),
+            path: Path::new(),
+            mode: DrawMode::Fill(FillOptions::default()),
+            mesh: QUAD_HANDLE.typed(),
+            render_pipelines: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
+                UI_SHAPE_PIPELINE_HANDLE.typed(),
+            )]),
+            visible: Visible {
+                is_transparent: true,
+                ..Visible::default()
+            },
             draw: Draw::default(),
             colors: ShapeColors {
                 main: Color::WHITE,

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -1,10 +1,10 @@
 //! Types for defining and using geometries.
 
-use bevy::transform::components::Transform;
+use bevy::{transform::components::Transform, ui::Style};
 use lyon_tessellation::path::{path::Builder, Path};
 
 use crate::{
-    entity::{ShapeBundle, ShapeColors},
+    entity::{ShapeBundle, ShapeColors, UiShapeBundle},
     utils::DrawMode,
 };
 
@@ -101,7 +101,7 @@ impl GeometryBuilder {
         self
     }
 
-    /// Generates a [`ShapeBundle`] using the data contained in the path
+    /// Returns a [`ShapeBundle`] using the data contained in the path
     /// builder.
     #[must_use]
     pub fn build(self, colors: ShapeColors, mode: DrawMode, transform: Transform) -> ShapeBundle {
@@ -114,7 +114,28 @@ impl GeometryBuilder {
         }
     }
 
+    /// Returns a [`UiShapeBundle`] using the data contained in the path
+    /// builder.
+    #[must_use]
+    pub fn build_ui(
+        self,
+        colors: ShapeColors,
+        mode: DrawMode,
+        style: Style,
+        z: f32,
+    ) -> UiShapeBundle {
+        UiShapeBundle {
+            path: self.0.build(),
+            colors,
+            mode,
+            style,
+            transform: Transform::from_xyz(0.0, 0.0, z),
+            ..UiShapeBundle::default()
+        }
+    }
+
     /// Generates a [`ShapeBundle`] with only one geometry.
+    ///
     /// Adds a geometry to the path builder.
     ///
     /// # Example
@@ -142,6 +163,21 @@ impl GeometryBuilder {
         let mut multishape = Self::new();
         multishape.add(shape);
         multishape.build(colors, mode, transform)
+    }
+
+    /// Generates a [`UiShapeBundle`] with only one geometry.
+    ///
+    /// Adds a geometry to the path builder.
+    pub fn build_ui_as(
+        shape: &impl Geometry,
+        colors: ShapeColors,
+        mode: DrawMode,
+        style: Style,
+        z: f32,
+    ) -> UiShapeBundle {
+        let mut multishape = Self::new();
+        multishape.add(shape);
+        multishape.build_ui(colors, mode, style, z)
     }
 }
 

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -117,19 +117,12 @@ impl GeometryBuilder {
     /// Returns a [`UiShapeBundle`] using the data contained in the path
     /// builder.
     #[must_use]
-    pub fn build_ui(
-        self,
-        colors: ShapeColors,
-        mode: DrawMode,
-        style: Style,
-        z: f32,
-    ) -> UiShapeBundle {
+    pub fn build_ui(self, colors: ShapeColors, mode: DrawMode, style: Style) -> UiShapeBundle {
         UiShapeBundle {
             path: self.0.build(),
             colors,
             mode,
             style,
-            transform: Transform::from_xyz(0.0, 0.0, z),
             ..UiShapeBundle::default()
         }
     }
@@ -173,11 +166,10 @@ impl GeometryBuilder {
         colors: ShapeColors,
         mode: DrawMode,
         style: Style,
-        z: f32,
     ) -> UiShapeBundle {
         let mut multishape = Self::new();
         multishape.add(shape);
-        multishape.build_ui(colors, mode, style, z)
+        multishape.build_ui(colors, mode, style)
     }
 }
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -15,7 +15,7 @@ use bevy::{
     app::{App, Plugin},
     asset::{Assets, Handle},
     ecs::{
-        query::{Added, Changed, Or},
+        query::{Changed, Or},
         schedule::{StageLabel, SystemStage},
         system::{Query, ResMut},
     },
@@ -99,6 +99,7 @@ impl Plugin for ShapePlugin {
             .add_system_to_stage(Stage::Shape, complete_shape_bundle_system);
 
         crate::render::add_shape_pipeline(&mut app.world);
+        crate::render::add_ui_shape_pipeline(&mut app.world);
     }
 }
 
@@ -111,9 +112,11 @@ fn complete_shape_bundle_system(
     mut stroke_tess: ResMut<StrokeTessellator>,
     mut query: Query<
         (&DrawMode, &Path, &mut Handle<Mesh>, &ShapeColors),
-        Or<(Added<Path>, Changed<ShapeColors>, Changed<DrawMode>)>,
+        Or<(Changed<Path>, Changed<ShapeColors>, Changed<DrawMode>)>,
     >,
 ) {
+    // TODO: Handle `Shape` component changed.
+
     for (tess_mode, path, mut mesh, colors) in query.iter_mut() {
         let mut buffers = VertexBuffers::new();
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -18,7 +18,11 @@ use bevy::{
 
 #[allow(missing_docs, clippy::unreadable_literal)]
 pub const SHAPE_PIPELINE_HANDLE: HandleUntyped =
-    HandleUntyped::weak_from_u64(PipelineDescriptor::TYPE_UUID, 3868147544761532180);
+    HandleUntyped::weak_from_u64(PipelineDescriptor::TYPE_UUID, 0x35ae6bb2984f7f14);
+
+#[allow(missing_docs, clippy::unreadable_literal)]
+pub const UI_SHAPE_PIPELINE_HANDLE: HandleUntyped =
+    HandleUntyped::weak_from_u64(PipelineDescriptor::TYPE_UUID, 0x158745fbe65cbe34);
 
 #[allow(clippy::too_many_lines)]
 fn build_shape_pipeline(shaders: &mut Assets<Shader>) -> PipelineDescriptor {
@@ -92,4 +96,73 @@ pub(crate) fn add_shape_pipeline(world: &mut World) {
         .unwrap();
     let mut shaders = world.get_resource_mut::<Assets<Shader>>().unwrap();
     pipelines.set_untracked(SHAPE_PIPELINE_HANDLE, build_shape_pipeline(&mut shaders));
+}
+
+#[allow(clippy::clippy::too_many_lines)]
+fn build_ui_shape_pipeline(shaders: &mut Assets<Shader>) -> PipelineDescriptor {
+    PipelineDescriptor {
+        depth_stencil: Some(DepthStencilState {
+            format: TextureFormat::Depth32Float,
+            depth_write_enabled: true,
+            depth_compare: CompareFunction::Less,
+            stencil: StencilState {
+                front: StencilFaceState::IGNORE,
+                back: StencilFaceState::IGNORE,
+                read_mask: 0,
+                write_mask: 0,
+            },
+            bias: DepthBiasState {
+                constant: 0,
+                slope_scale: 0.0,
+                clamp: 0.0,
+            },
+        }),
+        color_target_states: vec![ColorTargetState {
+            format: TextureFormat::default(),
+            blend: Some(BlendState {
+                color: BlendComponent {
+                    src_factor: BlendFactor::SrcAlpha,
+                    dst_factor: BlendFactor::OneMinusSrcAlpha,
+                    operation: BlendOperation::Add,
+                },
+                alpha: BlendComponent {
+                    src_factor: BlendFactor::One,
+                    dst_factor: BlendFactor::One,
+                    operation: BlendOperation::Add,
+                },
+            }),
+            write_mask: ColorWrite::ALL,
+        }],
+        primitive: PrimitiveState {
+            topology: PrimitiveTopology::TriangleList,
+            strip_index_format: None,
+            front_face: FrontFace::Cw,
+            cull_mode: Some(Face::Back),
+            polygon_mode: PolygonMode::Fill,
+            clamp_depth: false,
+            conservative: false,
+        },
+        ..PipelineDescriptor::new(ShaderStages {
+            vertex: shaders.add(Shader::from_glsl(
+                ShaderStage::Vertex,
+                include_str!("ui_shape.vert"),
+            )),
+            fragment: Some(shaders.add(Shader::from_glsl(
+                ShaderStage::Fragment,
+                include_str!("ui_shape.frag"),
+            ))),
+        })
+    }
+}
+
+pub(crate) fn add_ui_shape_pipeline(world: &mut World) {
+    let world = world.cell();
+    let mut pipelines = world
+        .get_resource_mut::<Assets<PipelineDescriptor>>()
+        .unwrap();
+    let mut shaders = world.get_resource_mut::<Assets<Shader>>().unwrap();
+    pipelines.set_untracked(
+        UI_SHAPE_PIPELINE_HANDLE,
+        build_ui_shape_pipeline(&mut shaders),
+    );
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -98,7 +98,7 @@ pub(crate) fn add_shape_pipeline(world: &mut World) {
     pipelines.set_untracked(SHAPE_PIPELINE_HANDLE, build_shape_pipeline(&mut shaders));
 }
 
-#[allow(clippy::clippy::too_many_lines)]
+#[allow(clippy::too_many_lines)]
 fn build_ui_shape_pipeline(shaders: &mut Assets<Shader>) -> PipelineDescriptor {
     PipelineDescriptor {
         depth_stencil: Some(DepthStencilState {

--- a/src/render/ui_shape.frag
+++ b/src/render/ui_shape.frag
@@ -1,0 +1,9 @@
+#version 450
+
+layout(location = 0) in vec4 v_color;
+
+layout(location = 0) out vec4 o_Target;
+
+void main() {
+    o_Target = v_color;
+}

--- a/src/render/ui_shape.vert
+++ b/src/render/ui_shape.vert
@@ -1,0 +1,20 @@
+#version 450
+
+layout(location = 0) in vec2 Vertex_Position_2D;
+layout(location = 1) in vec4 Vertex_Color;
+
+layout(location = 0) out vec4 v_color;
+
+layout(set = 0, binding = 0) uniform CameraViewProj {
+    mat4 ViewProj;
+};
+
+layout(set = 1, binding = 0) uniform Transform {
+    mat4 Object;
+};
+
+void main() {
+    v_color = Vertex_Color;
+    vec2 position = Vertex_Position_2D;
+    gl_Position = ViewProj * Object * vec4(position, 0.0, 1.0);
+}

--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -36,6 +36,8 @@ impl Default for RectangleOrigin {
     }
 }
 
+// TODO: Implement Rectangle::square(f32). Also use extents: Vec2 instead of width/height
+
 #[allow(missing_docs)]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Rectangle {

--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -36,7 +36,8 @@ impl Default for RectangleOrigin {
     }
 }
 
-// TODO: Implement Rectangle::square(f32). Also use extents: Vec2 instead of width/height
+// TODO: Implement Rectangle::square(f32). Also use extents: Vec2 instead of
+// width/height
 
 #[allow(missing_docs)]
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,6 +6,8 @@ use lyon_tessellation::{
     FillOptions, StrokeOptions,
 };
 
+// TODO: Include shape color(s) in DrawMode (Rename to DrawOptions).
+
 /// Determines how a shape will be drawn.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum DrawMode {


### PR DESCRIPTION
## Changes and usage notes

- Added `ui` example
- Added `build_ui` and `build_ui_as` as `GeometryBuilder` associated functions
- Changed render pipeline UUID handles to hexadecimal format
- Shapes will update on changed `Path`

Notes:
- `Size` won't have effect as I removed from the shader the `NodeSize` uniform. It would expect elements that would fit properly in a 1x1 pixel/units square to work properly, but `bevy_prototype_lyon` can't guarantee this condition at the moment.

## Comments

- It's recommended to check out the `ui` example to learn how to use `build_ui` and `build_ui_as` (spoiler: it's similar to the "normal" counterparts). Sorry if it's not minimal but I wanted to create something presentable...

cc: @inodentry, @alice-i-cecile, @rparrett 