### PR TITLE
Use #[derive(Component)]

### DIFF
--- a/examples/change_shape_example.rs
+++ b/examples/change_shape_example.rs
@@ -13,6 +13,7 @@ fn main() {
         .run();
 }
 
+#[derive(Component)]
 struct ExampleShape;
 
 fn rotate_shape_system(mut query: Query<&mut Transform, With<ExampleShape>>, time: Res<Time>) {

--- a/examples/svg_path_shape_example.rs
+++ b/examples/svg_path_shape_example.rs
@@ -10,9 +10,16 @@ fn main() {
         .add_startup_system(setup_system)
         .run();
 }
+
+#[derive(Component)]
 struct Name(String);
+
+#[derive(Component)]
 struct BlacksmithMarker;
+
+#[derive(Component)]
 struct ToolShackMarker;
+
 #[derive(Bundle)]
 struct BuildingBundle {
     name: Name,

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -44,17 +44,32 @@ const DEATH_ANIMATION_TIME: Duration = Duration::from_millis(700);
 const DAMAGE_COOLDOWN_TIME: Duration = Duration::from_millis(500);
 const HEALTH_BAR_WIDTH: f32 = 300.0;
 
+#[derive(Component)]
 struct Character;
+
+#[derive(Component)]
 struct Health(f32);
+
+#[derive(Component)]
 struct Lives(u32);
+
+#[derive(Component)]
 struct DamageCooldown(Timer);
+
+#[derive(Component)]
 struct HealthBar;
+
+#[derive(Component)]
 struct Heart(u32);
+
+#[derive(Component)]
 struct Animation {
     timer: Timer,
     initial_value: f32,
     final_value: f32,
 }
+
+#[derive(Component)]
 struct DeathAnimationTimer(Timer);
 
 fn main() {

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -1,10 +1,10 @@
 //! Types for defining shape color and options.
 
-use bevy::render::color::Color;
+use bevy::{ecs::component::Component, render::color::Color};
 use lyon_tessellation::{FillOptions, StrokeOptions};
 
 /// Determines how a shape will be drawn.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Component)]
 pub enum DrawMode {
     /// The shape will be filled using the provided [`FillMode`].
     Fill(FillMode),

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -2,7 +2,7 @@
 
 use bevy::{
     asset::Handle,
-    ecs::bundle::Bundle,
+    ecs::{bundle::Bundle, component::Component},
     render::{
         color::Color,
         draw::{Draw, Visible},
@@ -14,7 +14,7 @@ use bevy::{
     transform::components::{GlobalTransform, Transform},
     ui::{Node, Style},
 };
-use lyon_tessellation::{path::Path, FillOptions};
+use lyon_tessellation::{self as tess, FillOptions};
 
 use crate::{
     draw::{DrawMode, FillMode},
@@ -39,7 +39,7 @@ pub struct ShapeBundle {
 impl Default for ShapeBundle {
     fn default() -> Self {
         Self {
-            path: Path::new(),
+            path: Path(tess::path::Path::new()),
             mode: DrawMode::Fill(FillMode {
                 options: FillOptions::default(),
                 color: Color::WHITE,
@@ -81,7 +81,7 @@ impl Default for UiShapeBundle {
         Self {
             node: Node::default(),
             style: Style::default(),
-            path: Path::new(),
+            path: Path(tess::path::Path::new()),
             mode: DrawMode::Fill(FillMode {
                 options: FillOptions::default(),
                 color: Color::WHITE,
@@ -100,3 +100,7 @@ impl Default for UiShapeBundle {
         }
     }
 }
+
+#[allow(missing_docs)]
+#[derive(Component)]
+pub struct Path(pub tess::path::Path);

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -1,11 +1,11 @@
 //! Types for defining and using geometries.
 
 use bevy::{transform::components::Transform, ui::Style};
-use lyon_tessellation::path::{path::Builder, Path};
+use lyon_tessellation::{self as tess, path::path::Builder};
 
 use crate::{
     draw::DrawMode,
-    entity::{ShapeBundle, UiShapeBundle},
+    entity::{Path, ShapeBundle, UiShapeBundle},
 };
 
 /// Structs that implement this trait can be drawn as a shape. See the
@@ -54,7 +54,7 @@ pub trait Geometry {
 }
 
 /// This implementation permits to use a Lyon [`Path`] as a [`Geometry`].
-impl Geometry for Path {
+impl Geometry for tess::path::Path {
     fn add_geometry(&self, b: &mut Builder) {
         b.concatenate(&[self.as_slice()]);
     }
@@ -107,7 +107,7 @@ impl GeometryBuilder {
     #[must_use]
     pub fn build(self, mode: DrawMode, transform: Transform) -> ShapeBundle {
         ShapeBundle {
-            path: self.0.build(),
+            path: Path(self.0.build()),
             mode,
             transform,
             ..ShapeBundle::default()
@@ -119,7 +119,7 @@ impl GeometryBuilder {
     #[must_use]
     pub fn build_ui(self, mode: DrawMode, style: Style) -> UiShapeBundle {
         UiShapeBundle {
-            path: self.0.build(),
+            path: Path(self.0.build()),
             mode,
             style,
             ..UiShapeBundle::default()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,11 +35,12 @@ mod vertex;
 /// convenient imports.
 pub mod prelude {
     pub use lyon_tessellation::{
-        path::Path, FillOptions, FillRule, LineCap, LineJoin, Orientation, StrokeOptions,
+        self as tess, FillOptions, FillRule, LineCap, LineJoin, Orientation, StrokeOptions,
     };
 
     pub use crate::{
         draw::{DrawMode, FillMode, StrokeMode},
+        entity::Path,
         geometry::{Geometry, GeometryBuilder},
         path::{PathBuilder, ShapePath},
         plugin::ShapePlugin,

--- a/src/path.rs
+++ b/src/path.rs
@@ -3,10 +3,11 @@
 use bevy::math::Vec2;
 use lyon_tessellation::{
     geom::Angle,
-    path::{builder::WithSvg, path::Builder, EndpointId, Path},
+    path::{builder::WithSvg, path::Builder, EndpointId},
 };
 
 use crate::{
+    entity::Path,
     prelude::Geometry,
     utils::{ToPoint, ToVector},
 };
@@ -57,7 +58,7 @@ impl ShapePath {
     /// Builds the `Path` and returns it.
     #[must_use]
     pub fn build(self) -> Path {
-        self.0.build()
+        Path(self.0.build())
     }
 
     /// Directly builds a `Path` from a `shape`.
@@ -107,7 +108,7 @@ impl PathBuilder {
     /// Returns a finalized [`Path`].
     #[must_use]
     pub fn build(self) -> Path {
-        self.0.build()
+        Path(self.0.build())
     }
 
     /// Moves the current point to the given position.

--- a/src/path.rs
+++ b/src/path.rs
@@ -30,6 +30,7 @@ impl ShapePath {
     /// # use bevy::prelude::*;
     /// # use bevy_prototype_lyon::prelude::*;
     /// #
+    /// # #[derive(Component)]
     /// # struct Player;
     /// #
     /// fn my_system(mut query: Query<&mut Path, With<Player>>) {
@@ -69,6 +70,7 @@ impl ShapePath {
     /// # use bevy::prelude::*;
     /// # use bevy_prototype_lyon::prelude::*;
     /// #
+    /// # #[derive(Component)]
     /// # struct Player;
     /// #
     /// fn my_system(mut query: Query<&mut Path, With<Player>>) {

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -25,10 +25,11 @@ use bevy::{
         pipeline::PrimitiveTopology,
     },
 };
-use lyon_tessellation::{path::Path, BuffersBuilder, FillTessellator, StrokeTessellator};
+use lyon_tessellation::{self as tess, BuffersBuilder, FillTessellator, StrokeTessellator};
 
 use crate::{
     draw::{DrawMode, FillMode, StrokeMode},
+    entity::Path,
     vertex::{VertexBuffers, VertexConstructor},
 };
 
@@ -76,17 +77,17 @@ fn mesh_shapes_system(
 
         match tess_mode {
             DrawMode::Fill(mode) => {
-                fill(&mut fill_tess, path, mode, &mut buffers);
+                fill(&mut fill_tess, &path.0, mode, &mut buffers);
             }
             DrawMode::Stroke(mode) => {
-                stroke(&mut stroke_tess, path, mode, &mut buffers);
+                stroke(&mut stroke_tess, &path.0, mode, &mut buffers);
             }
             DrawMode::Outlined {
                 fill_mode,
                 outline_mode,
             } => {
-                fill(&mut fill_tess, path, fill_mode, &mut buffers);
-                stroke(&mut stroke_tess, path, outline_mode, &mut buffers);
+                fill(&mut fill_tess, &path.0, fill_mode, &mut buffers);
+                stroke(&mut stroke_tess, &path.0, outline_mode, &mut buffers);
             }
         }
 
@@ -97,7 +98,7 @@ fn mesh_shapes_system(
 #[allow(clippy::trivially_copy_pass_by_ref)] // lyon takes &FillOptions
 fn fill(
     tess: &mut ResMut<FillTessellator>,
-    path: &Path,
+    path: &tess::path::Path,
     mode: &FillMode,
     buffers: &mut VertexBuffers,
 ) {
@@ -113,7 +114,7 @@ fn fill(
 #[allow(clippy::trivially_copy_pass_by_ref)] // lyon takes &StrokeOptions
 fn stroke(
     tess: &mut ResMut<StrokeTessellator>,
-    path: &Path,
+    path: &tess::path::Path,
     mode: &StrokeMode,
     buffers: &mut VertexBuffers,
 ) {


### PR DESCRIPTION
The `main` branch of Bevy now requires `Component`s to be explicitly defined. I added `#[derive(Component)]` where necessary. I also wrapped `lyon_tessellation::path::Path` into a `Path` newtype in order to derive the `Component` trait on it.