### PR TITLE
Update deny.toml

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -25,6 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
       - name: Install cargo-deny
         run: cargo install cargo-deny
       - name: Check for security advisories and unmaintained crates
@@ -34,6 +38,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
       - name: Install cargo-deny
         run: cargo install cargo-deny
       - name: Check for banned and duplicated dependencies
@@ -43,6 +51,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
       - name: Install cargo-deny
         run: cargo install cargo-deny
       - name: Check for unauthorized licenses
@@ -52,6 +64,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
       - name: Install cargo-deny
         run: cargo install cargo-deny
       - name: Checked for unauthorized crate sources

--- a/deny.toml
+++ b/deny.toml
@@ -7,6 +7,9 @@ ignore = [
   "RUSTSEC-2020-0056", # stdweb unmaintained - https://github.com/koute/stdweb/issues/403
   "RUSTSEC-2021-0047", # security issue - https://github.com/gnzlbg/slice_deque/issues/90
   "RUSTSEC-2021-0096", # spirv_headers unmaintained
+  "RUSTSEC-2020-0159", # security issue - https://github.com/chronotope/chrono/issues/499
+  "RUSTSEC-2021-0119", # security issue - https://github.com/nix-rust/nix/issues/1541
+  "RUSTSEC-2020-0158", # slice_deque unmaintained - https://github.com/gnzlbg/slice_deque/issues/94
 ]
 notice = "deny"
 unmaintained = "deny"


### PR DESCRIPTION
Ignore upstream advisories emitted because this crate depends on Bevy.