### PR TITLE
Temporarily keep the old Bevy renderer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ version = "0.3.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = {git = "https://github.com/bevyengine/bevy", default-features = false, features = ["render"]}
+bevy = {git = "https://github.com/bevyengine/bevy", rev = "de8edd3", default-features = false, features = ["render"]}
 lyon_tessellation = "0.17"
 svgtypes = "0.5"
 [dev-dependencies]
-bevy = {git = "https://github.com/bevyengine/bevy"}
+bevy = {git = "https://github.com/bevyengine/bevy", rev = "de8edd3"}


### PR DESCRIPTION
This PR pins the last commit of Bevy that still has the old renderer. This will be reverted when I'll push the render pipeline compatible with the new renderer.

If you are depending on bleeding edge `bevy_prototype_lyon`, you will have to pin your bevy dependency as well, like:
```toml
bevy = {git = "https://github.com/bevyengine/bevy", rev = "de8edd3"}
```
Keep in mind that this will hold you back to the old renderer, but it is necessary for now if you wank to keep using `bevy_prototype_lyon`.

**I'll do my best to deliver the new pipeline as soon as possible.** I'm quite busy these days, so it could take from some days to some weeks to sort out this issue.