### PR TITLE
Apply clippy lints

### DIFF
--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -97,6 +97,7 @@ impl GeometryBuilder {
     /// # my_system.system();
     /// ```
     #[allow(clippy::should_implement_trait)]
+    #[must_use]
     pub fn add(mut self, shape: &impl Geometry) -> Self {
         shape.add_geometry(&mut self.0);
         self

--- a/src/path.rs
+++ b/src/path.rs
@@ -51,6 +51,7 @@ impl ShapePath {
     /// # my_system.system();
     /// ```
     #[allow(clippy::should_implement_trait)]
+    #[must_use]
     pub fn add(mut self, shape: &impl Geometry) -> Self {
         shape.add_geometry(&mut self.0);
         self


### PR DESCRIPTION
Complies to the recently added [`return_self_not_must_use`](https://rust-lang.github.io/rust-clippy/master/index.html#return_self_not_must_use) clippy lint