### PR TITLE
Random improvements

### DIFF
--- a/examples/dynamic_shape.rs
+++ b/examples/dynamic_shape.rs
@@ -1,3 +1,5 @@
+use std::f64::consts::PI;
+
 use bevy::prelude::*;
 use bevy_prototype_lyon::prelude::*;
 
@@ -41,7 +43,7 @@ fn change_draw_mode_system(mut query: Query<&mut DrawMode>, time: Res<Time>) {
 }
 
 fn change_number_of_sides(mut query: Query<&mut Path>, time: Res<Time>) {
-    let sides = (time.seconds_since_startup().sin() * 2.5 + 5.5).round() as usize;
+    let sides = ((time.seconds_since_startup() - PI * 2.5).sin() * 2.5 + 5.5).round() as usize;
 
     for mut path in query.iter_mut() {
         let polygon = shapes::RegularPolygon {

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -2,9 +2,12 @@
 
 use bevy::{
     ecs::{bundle::Bundle, component::Component},
-    prelude::{ComputedVisibility, GlobalTransform, Transform, Visibility},
-    render::color::Color,
+    render::{
+        color::Color,
+        view::{ComputedVisibility, Visibility},
+    },
     sprite::Mesh2dHandle,
+    transform::components::{GlobalTransform, Transform},
 };
 use lyon_tessellation::{self as tess, FillOptions};
 

--- a/src/path.rs
+++ b/src/path.rs
@@ -8,7 +8,7 @@ use lyon_tessellation::{
 
 use crate::{
     entity::Path,
-    prelude::Geometry,
+    geometry::Geometry,
     utils::{ToPoint, ToVector},
 };
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1,21 +1,30 @@
 //! Render pipeline
 
 use bevy::{
+    app::{App, Plugin},
+    asset::{Assets, HandleUntyped},
     core::FloatOrd,
     core_pipeline::Transparent2d,
-    prelude::*,
+    ecs::{
+        component::Component,
+        entity::Entity,
+        query::With,
+        system::{Commands, Local, Query, Res, ResMut},
+        world::{FromWorld, World},
+    },
     reflect::TypeUuid,
     render::{
+        mesh::Mesh,
         render_asset::RenderAssets,
         render_phase::{AddRenderCommand, DrawFunctions, RenderPhase, SetItemPipeline},
         render_resource::{
             BlendState, ColorTargetState, ColorWrites, FragmentState, FrontFace, MultisampleState,
-            PolygonMode, PrimitiveState, RenderPipelineCache, RenderPipelineDescriptor,
+            PolygonMode, PrimitiveState, RenderPipelineCache, RenderPipelineDescriptor, Shader,
             SpecializedPipeline, SpecializedPipelines, TextureFormat, VertexAttribute,
             VertexBufferLayout, VertexFormat, VertexState, VertexStepMode,
         },
         texture::BevyDefault,
-        view::VisibleEntities,
+        view::{ComputedVisibility, Msaa, VisibleEntities},
         RenderApp, RenderStage,
     },
     sprite::{


### PR DESCRIPTION
- Removed usage of prelude on dependencies
- Adjusted the starting number of sides in the `dynamic_shape` example. It now starts as a triangle, and gradually becomes an octagon, back and forth.