### PR TITLE
Implement `Geometry` for `Path`

### DIFF
--- a/examples/path.rs
+++ b/examples/path.rs
@@ -1,0 +1,25 @@
+use bevy::prelude::*;
+use bevy_prototype_lyon::prelude::*;
+
+fn main() {
+    App::new()
+        .insert_resource(Msaa { samples: 4 })
+        .add_plugins(DefaultPlugins)
+        .add_plugin(ShapePlugin)
+        .add_startup_system(setup_system)
+        .run();
+}
+
+fn setup_system(mut commands: Commands) {
+    let mut path_builder = PathBuilder::new();
+    path_builder.move_to(Vec2::ZERO);
+    path_builder.line_to(100.0 * Vec2::ONE);
+    let line = path_builder.build();
+
+    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+    commands.spawn_bundle(GeometryBuilder::build_as(
+        &line,
+        DrawMode::Stroke(StrokeMode::new(Color::BLACK, 10.0)),
+        Transform::default(),
+    ));
+}

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -13,6 +13,7 @@ use lyon_tessellation::{self as tess, FillOptions};
 
 use crate::{
     draw::{DrawMode, FillMode},
+    prelude::Geometry,
     render::Shape,
 };
 
@@ -51,3 +52,9 @@ impl Default for ShapeBundle {
 #[allow(missing_docs)]
 #[derive(Component)]
 pub struct Path(pub tess::path::Path);
+
+impl Geometry for Path {
+    fn add_geometry(&self, b: &mut tess::path::path::Builder) {
+        b.concatenate(&[self.0.as_slice()]);
+    }
+}

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -1,7 +1,7 @@
 //! Types for defining and using geometries.
 
 use bevy::transform::components::Transform;
-use lyon_tessellation::{self as tess, path::path::Builder};
+use lyon_tessellation::path::path::Builder;
 
 use crate::{
     draw::DrawMode,
@@ -51,13 +51,6 @@ use crate::{
 pub trait Geometry {
     /// Adds the geometry of the shape to the given Lyon path `Builder`.
     fn add_geometry(&self, b: &mut Builder);
-}
-
-/// This implementation permits to use a Lyon [`Path`] as a [`Geometry`].
-impl Geometry for tess::path::Path {
-    fn add_geometry(&self, b: &mut Builder) {
-        b.concatenate(&[self.as_slice()]);
-    }
 }
 
 /// Allows the creation of shapes using geometries added to a path builder.


### PR DESCRIPTION
Fixes:
- #138 

---

- Moved `Geometry` implementation from Lyon's `Path` to the wrapper `Path` defined locally (that implements `Component`).
- Added path example to avoid breaking the API unexpectedly.