### PR TITLE
Update vertex attributes to bevy main

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -130,7 +130,7 @@ fn stroke(
 fn build_mesh(buffers: &VertexBuffers) -> Mesh {
     let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
     mesh.set_indices(Some(Indices::U32(buffers.indices.clone())));
-    mesh.set_attribute(
+    mesh.insert_attribute(
         Mesh::ATTRIBUTE_POSITION,
         buffers
             .vertices
@@ -138,13 +138,13 @@ fn build_mesh(buffers: &VertexBuffers) -> Mesh {
             .map(|v| [v.position[0], v.position[1], 0.0])
             .collect::<Vec<[f32; 3]>>(),
     );
-    mesh.set_attribute(
+    mesh.insert_attribute(
         Mesh::ATTRIBUTE_COLOR,
         buffers
             .vertices
             .iter()
             .map(|v| v.color)
-            .collect::<Vec<[f32; 4]>>(),
+            .collect::<Vec<u32>>(),
     );
 
     mesh

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -20,8 +20,8 @@ use bevy::{
         render_resource::{
             BlendState, ColorTargetState, ColorWrites, FragmentState, FrontFace, MultisampleState,
             PolygonMode, PrimitiveState, RenderPipelineCache, RenderPipelineDescriptor, Shader,
-            SpecializedPipeline, SpecializedPipelines, TextureFormat, VertexAttribute,
-            VertexBufferLayout, VertexFormat, VertexState, VertexStepMode,
+            SpecializedPipeline, SpecializedPipelines, TextureFormat, VertexBufferLayout,
+            VertexFormat, VertexState, VertexStepMode,
         },
         texture::BevyDefault,
         view::{ComputedVisibility, Msaa, VisibleEntities},
@@ -60,25 +60,15 @@ impl SpecializedPipeline for ShapePipeline {
     fn specialize(&self, key: Self::Key) -> RenderPipelineDescriptor {
         // Customize how to store the meshes' vertex attributes in the vertex buffer
         // Our meshes only have position and color
-        let vertex_attributes = vec![
-            // Position (GOTCHA! Vertex_Position isn't first in the buffer due to how Mesh sorts
-            // attributes (alphabetically))
-            VertexAttribute {
-                format: VertexFormat::Float32x3,
-                // this offset is the size of the color attribute, which is stored first
-                offset: 16,
-                // position is available at location 0 in the shader
-                shader_location: 0,
-            },
+        let formats = vec![
+            // Position
+            VertexFormat::Float32x3,
             // Color
-            VertexAttribute {
-                format: VertexFormat::Float32x4,
-                offset: 0,
-                shader_location: 1,
-            },
+            VertexFormat::Uint32,
         ];
-        // This is the sum of the size of position and color attributes (12 + 16 = 28)
-        let vertex_array_stride = 28;
+
+        let vertex_layout =
+            VertexBufferLayout::from_vertex_formats(VertexStepMode::Vertex, formats);
 
         RenderPipelineDescriptor {
             vertex: VertexState {
@@ -87,11 +77,7 @@ impl SpecializedPipeline for ShapePipeline {
                 entry_point: "vertex".into(),
                 shader_defs: Vec::new(),
                 // Use our custom vertex buffer
-                buffers: vec![VertexBufferLayout {
-                    array_stride: vertex_array_stride,
-                    step_mode: VertexStepMode::Vertex,
-                    attributes: vertex_attributes,
-                }],
+                buffers: vec![vertex_layout],
             },
             fragment: Some(FragmentState {
                 // Use our custom shader

--- a/src/render/shape.wgsl
+++ b/src/render/shape.wgsl
@@ -8,7 +8,7 @@ var<uniform> mesh: Mesh2d;
 // The structure of the vertex buffer is as specified in `specialize()`
 struct Vertex {
     [[location(0)]] position: vec3<f32>;
-    [[location(1)]] color: vec4<f32>;
+    [[location(1)]] color: u32;
 };
 struct VertexOutput {
     // The vertex shader must set the on-screen position of the vertex
@@ -22,7 +22,7 @@ fn vertex(vertex: Vertex) -> VertexOutput {
     var out: VertexOutput;
     // Project the world position of the mesh into screen position
     out.clip_position = view.view_proj * mesh.model * vec4<f32>(vertex.position, 1.0);
-    out.color = vertex.color;
+    out.color = vec4<f32>((vec4<u32>(vertex.color) >> vec4<u32>(0u, 8u, 16u, 24u)) & vec4<u32>(255u)) / 255.0;
     return out;
 }
 // The input of the fragment shader must correspond to the output of the vertex shader for all `location`s

--- a/src/vertex.rs
+++ b/src/vertex.rs
@@ -13,7 +13,7 @@ pub type VertexBuffers = tess::VertexBuffers<Vertex, IndexType>;
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Vertex {
     pub position: [f32; 2],
-    pub color: [f32; 4],
+    pub color: u32,
 }
 
 /// Zero-sized type used to implement various vertex construction traits from
@@ -27,7 +27,7 @@ impl FillVertexConstructor<Vertex> for VertexConstructor {
     fn new_vertex(&mut self, vertex: FillVertex) -> Vertex {
         Vertex {
             position: [vertex.position().x, vertex.position().y],
-            color: self.color.as_linear_rgba_f32(),
+            color: self.color.as_linear_rgba_u32(),
         }
     }
 }
@@ -37,7 +37,7 @@ impl StrokeVertexConstructor<Vertex> for VertexConstructor {
     fn new_vertex(&mut self, vertex: StrokeVertex) -> Vertex {
         Vertex {
             position: [vertex.position().x, vertex.position().y],
-            color: self.color.as_linear_rgba_f32(),
+            color: self.color.as_linear_rgba_u32(),
         }
     }
 }


### PR DESCRIPTION
- Rename `Mesh::set_attribute` to `Mesh::insert_attribute`
- Use new `VertexBufferLayout::from_vertex_formats`
- Change vertex color attribute to a `u32`, obtained from new Color::as_linear_rgba_u32