### PR TITLE
Reduce Bevy dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ version = "0.4.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = {git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = ["render"]}
+bevy = {git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = ["bevy_sprite", "bevy_render", "bevy_core_pipeline"]}
 lyon_tessellation = "0.17"
 svgtypes = "0.5"
 
 [dev-dependencies]
-bevy = {git = "https://github.com/bevyengine/bevy", branch = "main"}
+bevy = {git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = ["x11"]}


### PR DESCRIPTION
Previously used `render` feature is a [group](
https://github.com/bevyengine/bevy/blob/a291b5aaedb4affcb31df2e2e63cb0c665ffb24a/Cargo.toml#L35-L43) that contains unneeded stuff, like `bevy_ui` or `bevy_text`. Specified features in this PR is the required minimum. You can read more about in in this issue: https://github.com/bevyengine/bevy/issues/4202

For `dev-dependencies` I left only `x11` feature. In Bevy this feature is enabled by default and it have no effect on platforms other then Linux (either `wayland` or `x11` is required to work on Linux). I tested changes on Windows and Linux.