### PR TITLE
`bevy_prototype_lyon 0.5`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ version = "0.5.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = {version = "0.7", default-features = false, features = ["bevy_sprite", "bevy_render", "bevy_core_pipeline"]}
+bevy = {git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = ["bevy_sprite", "bevy_render", "bevy_core_pipeline"]}
 lyon_tessellation = "0.17"
 svgtypes = "0.5"
 
 [dev-dependencies]
-bevy = {version = "0.7", default-features = false, features = ["x11"]}
+bevy = {git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = ["x11"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ version = "0.5.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = {git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = ["bevy_sprite", "bevy_render", "bevy_core_pipeline"]}
+bevy = {version = "0.7", default-features = false, features = ["bevy_sprite", "bevy_render", "bevy_core_pipeline"]}
 lyon_tessellation = "0.17"
 svgtypes = "0.5"
 
 [dev-dependencies]
-bevy = {git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = ["x11"]}
+bevy = {version = "0.7", default-features = false, features = ["x11"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "bevy_prototype_lyon"
 readme = "README.md"
 repository = "https://github.com/Nilirad/bevy_prototype_lyon/"
-version = "0.4.0"
+version = "0.5.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Currently Bevy does not support drawing custom shapes in an easy way. This crate
 
 ## Changelog
 
+### 0.5.0
+- Support for Bevy 0.7
+
 ### 0.4.0
 - Support for Bevy 0.6
 - Shape properties can be dynamically changed
@@ -44,7 +47,7 @@ Currently Bevy does not support drawing custom shapes in an easy way. This crate
 Add the following line in your `cargo.toml` manifest file, under the `[dependencies]` section:
 
 ```TOML
-bevy_prototype_lyon = "0.4.0"
+bevy_prototype_lyon = "0.5.0"
 ```
 
 Then, you can start by drawing simple shapes:
@@ -91,6 +94,7 @@ The following table shows the latest version of `bevy_prototype_lyon` that suppo
 
 |bevy|bevy_prototype_lyon|license|
 |---|---|---|
+|0.7|0.5|MIT/Apache 2.0|
 |0.6|0.4|MIT/Apache 2.0|
 |0.5|0.3|MIT|
 |0.4|0.2|MIT|


### PR DESCRIPTION
This version will support Bevy `0.7`.

Closes #153.