### PR TITLE
Remove dedicated `SystemStage`

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -45,7 +45,12 @@ impl Plugin for ShapePlugin {
         let stroke_tess = StrokeTessellator::new();
         app.insert_resource(fill_tess)
             .insert_resource(stroke_tess)
-            .add_system_to_stage(CoreStage::PostUpdate, mesh_shapes_system.label(BuildShapes))
+            .add_system_to_stage(
+                CoreStage::PostUpdate,
+                mesh_shapes_system
+                    .label(BuildShapes)
+                    .after(bevy::transform::transform_propagate_system),
+            )
             .add_plugin(RenderShapePlugin);
     }
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -16,10 +16,10 @@ use bevy::{
     asset::Assets,
     ecs::{
         query::{Changed, Or},
-        schedule::{StageLabel, SystemStage},
         system::{Query, ResMut},
     },
     log::error,
+    prelude::{CoreStage, ParallelSystemDescriptorCoercion as _, SystemLabel},
     render::{
         mesh::{Indices, Mesh},
         render_resource::PrimitiveTopology,
@@ -35,14 +35,6 @@ use crate::{
     vertex::{VertexBuffers, VertexConstructor},
 };
 
-/// Stages for this plugin.
-#[derive(Debug, Clone, Eq, Hash, PartialEq, StageLabel)]
-pub enum Stage {
-    /// The stage where the [`ShapeBundle`](crate::entity::ShapeBundle) gets
-    /// completed.
-    Shape,
-}
-
 /// A plugin that provides resources and a system to draw shapes in Bevy with
 /// less boilerplate.
 pub struct ShapePlugin;
@@ -53,15 +45,15 @@ impl Plugin for ShapePlugin {
         let stroke_tess = StrokeTessellator::new();
         app.insert_resource(fill_tess)
             .insert_resource(stroke_tess)
-            .add_stage_after(
-                bevy::app::CoreStage::PostUpdate,
-                Stage::Shape,
-                SystemStage::parallel(),
-            )
-            .add_system_to_stage(Stage::Shape, mesh_shapes_system)
+            .add_system_to_stage(CoreStage::PostUpdate, mesh_shapes_system.label(BuildShapes))
             .add_plugin(RenderShapePlugin);
     }
 }
+
+/// [`SystemLabel`] for the system that builds the meshes for newly-added
+/// or changed shapes. Resides in [`PosUpdate`](CoreStage::PostUpdate).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, SystemLabel)]
+pub struct BuildShapes;
 
 /// Queries all the [`ShapeBundle`]s to mesh them when they are added
 /// or re-mesh them when they are changed.

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -54,7 +54,7 @@ impl Plugin for ShapePlugin {
         app.insert_resource(fill_tess)
             .insert_resource(stroke_tess)
             .add_stage_after(
-                bevy::app::CoreStage::Update,
+                bevy::app::CoreStage::PostUpdate,
                 Stage::Shape,
                 SystemStage::parallel(),
             )

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -51,7 +51,7 @@ impl Plugin for ShapePlugin {
 }
 
 /// [`SystemLabel`] for the system that builds the meshes for newly-added
-/// or changed shapes. Resides in [`PosUpdate`](CoreStage::PostUpdate).
+/// or changed shapes. Resides in [`PostUpdate`](CoreStage::PostUpdate).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, SystemLabel)]
 pub struct BuildShapes;
 


### PR DESCRIPTION
This allows much more flexibility when building shapes. Currently, any shape building code must occur in or before `Update`, or else there will be visual flickering due to the frame delay. Moving the stage after `PostUpdate` gives the programmer more freedom, and allows shapes to be based on up-to-date `GlobalTransform`s.