### PR TITLE
Add rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
It seems like the project is being developed with rust nightly, as `rustfmt.toml` contains nightly-only stuff.

I think that adding a `rust-toolchain.toml` is the right thing to do? At the very least, it seems to make vscode's "format on save" work in my environment where nightly isn't the default toolchain.