### PR TITLE
Add `bevy_asset` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ version = "0.5.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = {git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = ["bevy_sprite", "bevy_render", "bevy_core_pipeline"]}
+bevy = {git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = ["bevy_sprite", "bevy_render", "bevy_core_pipeline", "bevy_asset"]}
 lyon_tessellation = "0.17"
 svgtypes = "0.5"
 
 [dev-dependencies]
-bevy = {git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = ["x11"]}
+bevy = {git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = ["x11", "bevy_asset"]}


### PR DESCRIPTION
- After bevyengine/bevy#5447, assets are behind the `bevy_asset` feature flag.

## Solution

- Add the `bevy_asset` feature to the `bevy` dependency and dev-dependency.