### PR TITLE
Update README for 0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Currently Bevy does not support drawing custom shapes in an easy way. This crate
 
 ## Changelog
 
+### 0.6.0
+
+- Support for Bevy 0.8
+
 ### 0.5.0
 - Support for Bevy 0.7
 
@@ -47,7 +51,7 @@ Currently Bevy does not support drawing custom shapes in an easy way. This crate
 Add the following line in your `cargo.toml` manifest file, under the `[dependencies]` section:
 
 ```TOML
-bevy_prototype_lyon = "0.5.0"
+bevy_prototype_lyon = "0.6.0"
 ```
 
 Then, you can start by drawing simple shapes:
@@ -72,7 +76,7 @@ fn setup_system(mut commands: Commands) {
         ..shapes::RegularPolygon::default()
     };
 
-    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+    commands.spawn_bundle(Camera2dBundle::default());
     commands.spawn_bundle(GeometryBuilder::build_as(
         &shape,
         DrawMode::Outlined {
@@ -94,6 +98,7 @@ The following table shows the latest version of `bevy_prototype_lyon` that suppo
 
 |bevy|bevy_prototype_lyon|license|
 |---|---|---|
+|0.8|0.6|MIT/Apache 2.0|
 |0.7|0.5|MIT/Apache 2.0|
 |0.6|0.4|MIT/Apache 2.0|
 |0.5|0.3|MIT|


### PR DESCRIPTION
The readme got updated for the release, but the main branch is still showing an outdated example, changelog, and support table.

Just copied the file over from the release branch.