### PR TITLE
Explicitely derive resources

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -16,17 +16,17 @@ use bevy::{
     asset::Assets,
     ecs::{
         query::{Changed, Or},
-        system::{Query, ResMut},
+        system::{Query, ResMut, Resource},
     },
     log::error,
-    prelude::{CoreStage, ParallelSystemDescriptorCoercion as _, SystemLabel},
+    prelude::{CoreStage, Deref, DerefMut, ParallelSystemDescriptorCoercion as _, SystemLabel},
     render::{
         mesh::{Indices, Mesh},
         render_resource::PrimitiveTopology,
     },
     sprite::Mesh2dHandle,
 };
-use lyon_tessellation::{self as tess, BuffersBuilder, FillTessellator, StrokeTessellator};
+use lyon_tessellation::{self as tess, BuffersBuilder};
 
 use crate::{
     draw::{DrawMode, FillMode, StrokeMode},
@@ -41,10 +41,10 @@ pub struct ShapePlugin;
 
 impl Plugin for ShapePlugin {
     fn build(&self, app: &mut App) {
-        let fill_tess = FillTessellator::new();
-        let stroke_tess = StrokeTessellator::new();
-        app.insert_resource(fill_tess)
-            .insert_resource(stroke_tess)
+        let fill_tess = lyon_tessellation::FillTessellator::new();
+        let stroke_tess = lyon_tessellation::StrokeTessellator::new();
+        app.insert_resource(FillTessellator(fill_tess))
+            .insert_resource(StrokeTessellator(stroke_tess))
             .add_system_to_stage(
                 CoreStage::PostUpdate,
                 mesh_shapes_system
@@ -146,3 +146,9 @@ fn build_mesh(buffers: &VertexBuffers) -> Mesh {
 
     mesh
 }
+
+#[derive(Resource, Deref, DerefMut)]
+struct FillTessellator(lyon_tessellation::FillTessellator);
+
+#[derive(Resource, Deref, DerefMut)]
+struct StrokeTessellator(lyon_tessellation::StrokeTessellator);

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -8,7 +8,7 @@ use bevy::{
         component::Component,
         entity::Entity,
         query::With,
-        system::{Commands, Local, Query, Res, ResMut},
+        system::{Commands, Local, Query, Res, ResMut, Resource},
         world::{FromWorld, World},
     },
     reflect::TypeUuid,
@@ -38,6 +38,7 @@ use bevy::{
 pub struct Shape;
 
 /// Custom pipeline for 2d meshes with vertex colors
+#[derive(Resource)]
 struct ShapePipeline {
     /// this pipeline wraps the standard [`Mesh2dPipeline`]
     mesh2d_pipeline: Mesh2dPipeline,


### PR DESCRIPTION
- After bevyengine/bevy#5577 got merged, the `Resource` trait must be explicitely implemented.

I derived `Resource` for all the previous resources, and I created `#[derive(Resource)]` newtypes for external types that were used as resources.