### PR TITLE
Fix rectangle shape origin and size

### DIFF
--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -6,7 +6,7 @@
 
 use bevy::math::Vec2;
 use lyon_tessellation::{
-    geom::euclid::default::Point2D,
+    geom::euclid::default::Size2D,
     math::{point, Angle, Box2D, Point, Vector},
     path::{
         builder::WithSvg, path::Builder, traits::SvgPathBuilder, ArcFlags, Polygon as LyonPolygon,
@@ -68,7 +68,7 @@ impl Geometry for Rectangle {
         };
 
         b.add_rectangle(
-            &Box2D::new(origin, Point2D::new(self.extents.x, self.extents.y)),
+            &Box2D::from_origin_and_size(origin, Size2D::new(self.extents.x, self.extents.y)),
             Winding::Positive,
         );
     }


### PR DESCRIPTION
Fixes https://github.com/Nilirad/bevy_prototype_lyon/issues/179

This fixes an issue with the rectangle shape building that was introduced when the call to Rect::new was changed to a Box2d::new (the former takes extrema points and the latter takes an origin and size).

@Nilirad  Do you think it's possible to bump the minor version for it?