### PR TITLE
Port to stageless schedule

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -19,7 +19,7 @@ use bevy::{
         system::{Query, ResMut, Resource},
     },
     log::error,
-    prelude::{Deref, DerefMut, IntoSystemConfig, SystemSet},
+    prelude::{CoreSet, Deref, DerefMut, IntoSystemConfig, IntoSystemSetConfig, SystemSet},
     render::{
         mesh::{Indices, Mesh},
         render_resource::PrimitiveTopology,
@@ -45,11 +45,12 @@ impl Plugin for ShapePlugin {
         let stroke_tess = lyon_tessellation::StrokeTessellator::new();
         app.insert_resource(FillTessellator(fill_tess))
             .insert_resource(StrokeTessellator(stroke_tess))
-            .add_system(
-                mesh_shapes_system
-                    .in_set(BuildShapes)
+            .configure_set(
+                BuildShapes
+                    .in_base_set(CoreSet::PostUpdate)
                     .after(bevy::transform::TransformSystem::TransformPropagate),
             )
+            .add_system(mesh_shapes_system.in_set(BuildShapes))
             .add_plugin(RenderShapePlugin);
     }
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -19,7 +19,7 @@ use bevy::{
         system::{Query, ResMut, Resource},
     },
     log::error,
-    prelude::{CoreStage, Deref, DerefMut, IntoSystemDescriptor, SystemLabel},
+    prelude::{Deref, DerefMut, IntoSystemConfig, SystemSet},
     render::{
         mesh::{Indices, Mesh},
         render_resource::PrimitiveTopology,
@@ -45,10 +45,9 @@ impl Plugin for ShapePlugin {
         let stroke_tess = lyon_tessellation::StrokeTessellator::new();
         app.insert_resource(FillTessellator(fill_tess))
             .insert_resource(StrokeTessellator(stroke_tess))
-            .add_system_to_stage(
-                CoreStage::PostUpdate,
+            .add_system(
                 mesh_shapes_system
-                    .label(BuildShapes)
+                    .in_set(BuildShapes)
                     .after(bevy::transform::TransformSystem::TransformPropagate),
             )
             .add_plugin(RenderShapePlugin);
@@ -57,7 +56,7 @@ impl Plugin for ShapePlugin {
 
 /// [`SystemLabel`] for the system that builds the meshes for newly-added
 /// or changed shapes. Resides in [`PostUpdate`](CoreStage::PostUpdate).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, SystemLabel)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, SystemSet)]
 pub struct BuildShapes;
 
 /// Queries all the [`ShapeBundle`]s to mesh them when they are added

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -25,7 +25,7 @@ use bevy::{
         },
         texture::BevyDefault,
         view::{ComputedVisibility, ExtractedView, Msaa, ViewTarget, VisibleEntities},
-        Extract, RenderApp, RenderSet,
+        Extract, ExtractSchedule, RenderApp, RenderSet,
     },
     sprite::{
         DrawMesh2d, Mesh2dHandle, Mesh2dPipeline, Mesh2dPipelineKey, Mesh2dUniform,
@@ -157,7 +157,7 @@ impl Plugin for RenderShapePlugin {
             .add_render_command::<Transparent2d, DrawShape>()
             .init_resource::<ShapePipeline>()
             .init_resource::<SpecializedRenderPipelines<ShapePipeline>>()
-            .add_system(extract_shape.in_set(RenderSet::ExtractCommands))
+            .add_system_to_schedule(ExtractSchedule, extract_shape)
             .add_system(queue_shape.in_set(RenderSet::Queue));
     }
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -7,6 +7,7 @@ use bevy::{
     ecs::{
         component::Component,
         entity::Entity,
+        prelude::IntoSystemConfig,
         query::With,
         system::{Commands, Local, Query, Res, ResMut, Resource},
         world::{FromWorld, World},
@@ -24,7 +25,7 @@ use bevy::{
         },
         texture::BevyDefault,
         view::{ComputedVisibility, ExtractedView, Msaa, ViewTarget, VisibleEntities},
-        Extract, RenderApp, RenderStage,
+        Extract, RenderApp, RenderSet,
     },
     sprite::{
         DrawMesh2d, Mesh2dHandle, Mesh2dPipeline, Mesh2dPipelineKey, Mesh2dUniform,
@@ -156,8 +157,8 @@ impl Plugin for RenderShapePlugin {
             .add_render_command::<Transparent2d, DrawShape>()
             .init_resource::<ShapePipeline>()
             .init_resource::<SpecializedRenderPipelines<ShapePipeline>>()
-            .add_system_to_stage(RenderStage::Extract, extract_shape)
-            .add_system_to_stage(RenderStage::Queue, queue_shape);
+            .add_system(extract_shape.in_set(RenderSet::ExtractCommands))
+            .add_system(queue_shape.in_set(RenderSet::Queue));
     }
 }
 


### PR DESCRIPTION
This is a first attempt to porting the library to Bevy's stageless schedule. It compiles, but at the moment the examples panic for a dependency cycle in the schedule.