### PR TITLE
Flatten nested MaterialMesh2dBundle

### DIFF
--- a/src/entity.rs
+++ b/src/entity.rs
@@ -2,8 +2,9 @@
 
 use bevy::{
     ecs::{bundle::Bundle, component::Component},
+    prelude::{ComputedVisibility, GlobalTransform, Handle, Transform, Visibility},
     render::color::Color,
-    sprite::MaterialMesh2dBundle,
+    sprite::Mesh2dHandle,
 };
 use lyon_tessellation::{self as tess, FillOptions};
 
@@ -17,8 +18,12 @@ use crate::{
 #[allow(missing_docs)]
 #[derive(Bundle)]
 pub struct ShapeBundle {
-    #[bundle]
-    pub mesh2d_bundle: MaterialMesh2dBundle<ShapeMaterial>,
+    pub mesh: Mesh2dHandle,
+    pub material: Handle<ShapeMaterial>,
+    pub transform: Transform,
+    pub global_transform: GlobalTransform,
+    pub visibility: Visibility,
+    pub computed_visibility: ComputedVisibility,
     pub path: Path,
     pub mode: DrawMode,
 }
@@ -31,7 +36,12 @@ impl Default for ShapeBundle {
                 options: FillOptions::default(),
                 color: Color::WHITE,
             }),
-            mesh2d_bundle: MaterialMesh2dBundle::<ShapeMaterial>::default(),
+            material: Handle::<ShapeMaterial>::default(),
+            mesh: Mesh2dHandle::default(),
+            transform: Transform::default(),
+            global_transform: GlobalTransform::default(),
+            visibility: Visibility::default(),
+            computed_visibility: ComputedVisibility::default(),
         }
     }
 }

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -18,14 +18,14 @@ use crate::{
 #[allow(missing_docs)]
 #[derive(Bundle)]
 pub struct ShapeBundle {
+    pub path: Path,
+    pub mode: DrawMode,
     pub mesh: Mesh2dHandle,
     pub material: Handle<ShapeMaterial>,
     pub transform: Transform,
     pub global_transform: GlobalTransform,
     pub visibility: Visibility,
     pub computed_visibility: ComputedVisibility,
-    pub path: Path,
-    pub mode: DrawMode,
 }
 
 impl Default for ShapeBundle {
@@ -36,8 +36,8 @@ impl Default for ShapeBundle {
                 options: FillOptions::default(),
                 color: Color::WHITE,
             }),
-            material: Handle::<ShapeMaterial>::default(),
             mesh: Mesh2dHandle::default(),
+            material: Handle::<ShapeMaterial>::default(),
             transform: Transform::default(),
             global_transform: GlobalTransform::default(),
             visibility: Visibility::default(),

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -1,6 +1,6 @@
 //! Types for defining and using geometries.
 
-use bevy::{sprite::MaterialMesh2dBundle, transform::components::Transform};
+use bevy::transform::components::Transform;
 use lyon_tessellation::path::path::Builder;
 
 use crate::{
@@ -103,10 +103,8 @@ impl GeometryBuilder {
         ShapeBundle {
             path: Path(self.0.build()),
             mode,
-            mesh2d_bundle: MaterialMesh2dBundle {
-                transform,
-                ..MaterialMesh2dBundle::default()
-            },
+            transform,
+            ..Default::default()
         }
     }
 


### PR DESCRIPTION
This flattens `ShapeBundle` to remove the nested `MaterialMesh2dBundle`.

This fixes a UX issue introduced by #196 where if a user wants to spawn a `ShapeBundle` with an overridden component, they would have to do something silly like

```rust
let mut shape_bundle = GeometryBuilder::build_as(
    &shape,
    DrawMode::Outlined {
        fill_mode: FillMode::color(Color::CYAN),
        outline_mode: StrokeMode::new(Color::BLACK, 10.0),
    },
    Transform::default(),
);
shape_bundle.mesh2d_bundle.visibility = Visibility::Hidden;
commands.spawn((
    shape_bundle,
    ExampleShape,
));

// Or (not bevy best-practice for performance)
commands
    .spawn((
        GeometryBuilder::build_as(
            &shape,
            DrawMode::Outlined {
                fill_mode: FillMode::color(Color::CYAN),
                outline_mode: StrokeMode::new(Color::BLACK, 10.0),
            },
            Transform::default(),
        ),
        ExampleShape,
    ))
    .insert(Visibility::Hidden);
```

After this PR, they could "simply"

```rust
commands.spawn((
    ShapeBundle {
        visibility: Visibility::Hidden,
        ..GeometryBuilder::build_as(
            &shape,
            DrawMode::Outlined {
                fill_mode: FillMode::color(Color::CYAN),
                outline_mode: StrokeMode::new(Color::BLACK, 10.0),
            },
            Transform::default(),
        )
    },
    ExampleShape,
));
```

See also: more discussion of spawn ergonomics in https://github.com/Nilirad/bevy_prototype_lyon/pull/198#issuecomment-1421660583