### PR TITLE
Added `RoundedPolygon`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ version = "0.7.2"
 [dependencies]
 bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = ["bevy_sprite", "bevy_render", "bevy_core_pipeline", "bevy_asset"] }
 lyon_tessellation = "1"
+lyon_algorithms = "1"
 svgtypes = "0.8"
 
 [dev-dependencies]

--- a/examples/rounded_polygon.rs
+++ b/examples/rounded_polygon.rs
@@ -1,6 +1,3 @@
-//! This is the example that goes to the README.md file. The README.md should be
-//! updated before every release.
-
 use bevy::prelude::*;
 use bevy_prototype_lyon::prelude::*;
 

--- a/examples/rounded_polygon.rs
+++ b/examples/rounded_polygon.rs
@@ -1,0 +1,42 @@
+//! This is the example that goes to the README.md file. The README.md should be
+//! updated before every release.
+
+use bevy::prelude::*;
+use bevy_prototype_lyon::prelude::*;
+
+fn main() {
+    App::new()
+        .insert_resource(Msaa::Sample4)
+        .add_plugins(DefaultPlugins)
+        .add_plugin(ShapePlugin)
+        .add_startup_system(setup_system)
+        .run();
+}
+
+fn setup_system(mut commands: Commands) {
+    let points = [
+        Vec2::new(-1.0, -0.3),
+        Vec2::new(0.0, -0.3),
+        Vec2::new(0.0, -1.0),
+        Vec2::new(1.5, 0.0),
+        Vec2::new(0.0, 1.0),
+        Vec2::new(0.0, 0.3),
+        Vec2::new(-1.0, 0.3),
+    ]
+    .map(|x| x * 100.);
+
+    let shape = shapes::RoundedPolygon {
+        points: points.into_iter().collect(),
+        radius: 10.,
+        closed: false,
+    };
+
+    commands.spawn(Camera2dBundle::default());
+    commands.spawn((
+        ShapeBundle {
+            path: GeometryBuilder::build_as(&shape),
+            ..default()
+        },
+        Fill::color(Color::CYAN),
+    ));
+}

--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -189,7 +189,7 @@ impl Geometry for RoundedPolygon {
             polygon,
             self.radius,
             lyon_algorithms::path::NO_ATTRIBUTES,
-        )
+        );
     }
 }
 

--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -155,6 +155,44 @@ impl Geometry for Polygon {
     }
 }
 
+#[allow(missing_docs)]
+#[derive(Debug, Clone, PartialEq)]
+pub struct RoundedPolygon {
+    pub points: Vec<Vec2>,
+    pub radius: f32,
+    pub closed: bool,
+}
+
+impl Default for RoundedPolygon {
+    fn default() -> Self {
+        Self {
+            points: Vec::new(),
+            radius: 0.0,
+            closed: true,
+        }
+    }
+}
+
+impl Geometry for RoundedPolygon {
+    fn add_geometry(&self, b: &mut Builder) {
+        let points = self
+            .points
+            .iter()
+            .map(|p| p.to_point())
+            .collect::<Vec<Point>>();
+        let polygon: LyonPolygon<Point> = LyonPolygon {
+            points: points.as_slice(),
+            closed: self.closed,
+        };
+        lyon_algorithms::rounded_polygon::add_rounded_polygon(
+            b,
+            polygon,
+            self.radius,
+            lyon_algorithms::path::NO_ATTRIBUTES,
+        )
+    }
+}
+
 /// The regular polygon feature used to determine the dimensions of the polygon.
 #[allow(missing_docs)]
 #[derive(Debug, Clone, Copy, PartialEq)]


### PR DESCRIPTION
Closes https://github.com/Nilirad/bevy_prototype_lyon/issues/194

- Added a `RoundedPolygon` struct in `shapes`
- Added a `rounded_polygon` example (feel free to delete)
- Introduced a dependency on `lyon_algorithms`


