### PR TITLE
Link to latest release examples from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ fn setup_system(mut commands: Commands) {
 }
 ```
 
-Don't forget to check out the [examples](examples/) to learn more!
+Don't forget to check out the [examples](https://github.com/Nilirad/bevy_prototype_lyon/tree/latest/examples) to learn more!
 
 ## Bevy versions supported
 


### PR DESCRIPTION
`README.md` will now link to examples in the `latest` branch, whose purpose is to host the source code for the latest release of `bevy_prototype_lyon`.