### PR TITLE
Track Bevy release on default branch

### DIFF
--- a/.github/workflows/ci-cron.yml
+++ b/.github/workflows/ci-cron.yml
@@ -1,10 +1,8 @@
-name: CI
+name: CI-cron
 
 on:
-  pull_request:
-    branches: [master, bevy-main]
-  push:
-    branches: [master, bevy-main]
+  schedule:
+    - cron: 0 9 * * *
 
 env:
   CARGO_TERM_COLOR: always
@@ -19,6 +17,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: bevy-main
       
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -24,7 +24,9 @@ jobs:
   check-advisories:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          ref: bevy-main
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -37,7 +39,9 @@ jobs:
   check-bans:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          ref: bevy-main
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -50,7 +54,9 @@ jobs:
   check-licenses:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          ref: bevy-main
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -63,7 +69,9 @@ jobs:
   check-sources:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          ref: bevy-main
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ version = "0.8.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = ["bevy_sprite", "bevy_render", "bevy_core_pipeline", "bevy_asset"] }
+bevy = { version = "0.10", default-features = false, features = ["bevy_sprite", "bevy_render", "bevy_core_pipeline", "bevy_asset"] }
 lyon_tessellation = "1"
 lyon_algorithms = "1"
 svgtypes = "0.8"
 
 [dev-dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = ["x11", "bevy_asset"] }
+bevy = { version = "0.10", default-features = false, features = ["x11", "bevy_asset"] }


### PR DESCRIPTION
Since Bevy adopted a train release schedule, it makes less sense to closely track Bevy's `main` branch. This PR will make the `master` branch depend on Bevy 0.10. I already pushed a `bevy-main` branch that tracks Bevy as we always did. I also adapted the GitHub Actions workflows to also work with `bevy-main`.

The new PR policy will be that changes should be targeted preferably on the `master` branch, while `bevy_main` is for fixing breaking changes and for using Bevy features not yet supported on release.

## TODO

- [x] Add a `Contributing.md` guide to help developers choose the right target branch. This will be done in a separate PR.
- [ ] Develop and document a merge strategy of `bevy-main` into `master`, needed each time a new Bevy version releases.