### PR TITLE
Format doc comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ fn main() {
     App::new()
         .insert_resource(Msaa::Sample4)
         .add_plugins(DefaultPlugins)
-        .add_plugin(ShapePlugin)
+        .add_plugins(ShapePlugin)
         .add_systems(Startup, setup_system)
         .run();
 }

--- a/examples/dynamic_shape.rs
+++ b/examples/dynamic_shape.rs
@@ -7,7 +7,7 @@ fn main() {
     App::new()
         .insert_resource(Msaa::Sample4)
         .add_plugins(DefaultPlugins)
-        .add_plugin(ShapePlugin)
+        .add_plugins(ShapePlugin)
         .add_systems(Startup, setup_system)
         .add_systems(Update, change_draw_mode_system)
         .add_systems(Update, change_number_of_sides)

--- a/examples/path.rs
+++ b/examples/path.rs
@@ -5,7 +5,7 @@ fn main() {
     App::new()
         .insert_resource(Msaa::Sample4)
         .add_plugins(DefaultPlugins)
-        .add_plugin(ShapePlugin)
+        .add_plugins(ShapePlugin)
         .add_systems(Startup, setup_system)
         .run();
 }

--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -8,7 +8,7 @@ fn main() {
     App::new()
         .insert_resource(Msaa::Sample4)
         .add_plugins(DefaultPlugins)
-        .add_plugin(ShapePlugin)
+        .add_plugins(ShapePlugin)
         .add_systems(Startup, setup_system)
         .run();
 }

--- a/examples/rounded_polygon.rs
+++ b/examples/rounded_polygon.rs
@@ -5,7 +5,7 @@ fn main() {
     App::new()
         .insert_resource(Msaa::Sample4)
         .add_plugins(DefaultPlugins)
-        .add_plugin(ShapePlugin)
+        .add_plugins(ShapePlugin)
         .add_systems(Startup, setup_system)
         .run();
 }

--- a/examples/svg.rs
+++ b/examples/svg.rs
@@ -6,7 +6,7 @@ fn main() {
         //Added msaa to reduce aliasing
         .insert_resource(Msaa::Sample4)
         .add_plugins(DefaultPlugins)
-        .add_plugin(ShapePlugin)
+        .add_plugins(ShapePlugin)
         .add_systems(Startup, setup_system)
         .run();
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -52,7 +52,7 @@ impl Plugin for ShapePlugin {
                 BuildShapes.after(bevy::transform::TransformSystem::TransformPropagate),
             )
             .add_systems(PostUpdate, mesh_shapes_system.in_set(BuildShapes))
-            .add_plugin(ShapeMaterialPlugin);
+            .add_plugins(ShapeMaterialPlugin);
     }
 }
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -24,7 +24,7 @@ impl Plugin for ShapeMaterialPlugin {
             Shader::from_wgsl
         );
 
-        app.add_plugin(Material2dPlugin::<ShapeMaterial>::default())
+        app.add_plugins(Material2dPlugin::<ShapeMaterial>::default())
             .register_asset_reflect::<ShapeMaterial>();
 
         app.world

--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -291,12 +291,12 @@ impl Geometry for Line {
 ///offset the coordinates of the paths
 ///
 ///In inkscape for example, to turn your units into pixels, you:
-///1) Go to File>Document Properties>General>Display Units and set it to px
+/// 1) Go to File>Document Properties>General>Display Units and set it to px
 ///
-///2) In File>Document Properties>Custom Size>Units set it to px, also, this
+/// 2) In File>Document Properties>Custom Size>Units set it to px, also, this
 /// size would be used for `svg_doc_size_in_px`
 ///
-///3) In File>Document Properties>Scale>Scale x make sure it is set to 1 User
+/// 3) In File>Document Properties>Scale>Scale x make sure it is set to 1 User
 /// unit per px
 ///
 ///Example exists in the examples folder


### PR DESCRIPTION
- Formats doc comments
- Uses `bevy_app::App::add_plugins` instead of `add_plugin` (which is now deprecated).