### PR TITLE
Fix shader

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -73,7 +73,7 @@ fn mesh_shapes_system(
         Or<(Changed<Path>, Changed<Fill>, Changed<Stroke>)>,
     >,
 ) {
-    for (maybe_fill_mode, maybe_stroke_mode, path, mut mesh) in query.iter_mut() {
+    for (maybe_fill_mode, maybe_stroke_mode, path, mut mesh) in &mut query {
         let mut buffers = VertexBuffers::new();
 
         if let Some(fill_mode) = maybe_fill_mode {

--- a/src/render/shape_material.wgsl
+++ b/src/render/shape_material.wgsl
@@ -1,5 +1,6 @@
-#import bevy_sprite::mesh2d_types
+#import bevy_sprite::mesh2d_types  Mesh2d
 #import bevy_sprite::mesh2d_view_bindings
+#import bevy_sprite::mesh2d_vertex_output  MeshVertexOutput
 
 @group(1) @binding(1)
 var texture: texture_2d<f32>;
@@ -8,11 +9,7 @@ var texture_sampler: sampler;
 @group(2) @binding(0)
 var<uniform> mesh: Mesh2d;
 
-struct FragmentInput {
-    #import bevy_sprite::mesh2d_vertex_output
-};
-
 @fragment
-fn fragment(in: FragmentInput) -> @location(0) vec4<f32> {
+fn fragment(in: MeshVertexOutput) -> @location(0) vec4<f32> {
     return in.color;
 }


### PR DESCRIPTION
bevyengine/bevy#5703 changed how WGSL shaders are imported in Bevy. This PR fixes `shape_material.wgsl` to correctly import Bevy shader structs.