### PR TITLE
Revert "Rename `Color` to `LegacyColor`"

### DIFF
--- a/examples/dynamic_shape.rs
+++ b/examples/dynamic_shape.rs
@@ -31,7 +31,7 @@ fn change_draw_mode_system(mut query: Query<(&mut Fill, &mut Stroke)>, time: Res
     let outline_width = 2.0 + time.elapsed_seconds_f64().sin().abs() * 10.0;
 
     for (mut fill_mode, mut stroke_mode) in query.iter_mut() {
-        fill_mode.color = LegacyColor::hsl(hue as f32, 1.0, 0.5);
+        fill_mode.color = Color::hsl(hue as f32, 1.0, 0.5);
         stroke_mode.options.line_width = outline_width as f32;
     }
 }
@@ -63,8 +63,8 @@ fn setup_system(mut commands: Commands) {
             path: GeometryBuilder::build_as(&shape),
             ..default()
         },
-        Fill::color(LegacyColor::CYAN),
-        Stroke::new(LegacyColor::BLACK, 10.0),
+        Fill::color(Color::CYAN),
+        Stroke::new(Color::BLACK, 10.0),
         ExampleShape,
     ));
 }

--- a/examples/path.rs
+++ b/examples/path.rs
@@ -36,7 +36,7 @@ fn setup_system(mut commands: Commands) {
             },
             ..default()
         },
-        Stroke::new(LegacyColor::BLACK, 10.0),
-        Fill::color(LegacyColor::RED),
+        Stroke::new(Color::BLACK, 10.0),
+        Fill::color(Color::RED),
     ));
 }

--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -26,7 +26,7 @@ fn setup_system(mut commands: Commands) {
             path: GeometryBuilder::build_as(&shape),
             ..default()
         },
-        Fill::color(LegacyColor::CYAN),
-        Stroke::new(LegacyColor::BLACK, 10.0),
+        Fill::color(Color::CYAN),
+        Stroke::new(Color::BLACK, 10.0),
     ));
 }

--- a/examples/rounded_polygon.rs
+++ b/examples/rounded_polygon.rs
@@ -34,6 +34,6 @@ fn setup_system(mut commands: Commands) {
             path: GeometryBuilder::build_as(&shape),
             ..default()
         },
-        Fill::color(LegacyColor::CYAN),
+        Fill::color(Color::CYAN),
     ));
 }

--- a/examples/svg.rs
+++ b/examples/svg.rs
@@ -43,7 +43,7 @@ fn setup_system(mut commands: Commands) {
                     }),
                     ..default()
                 },
-                Stroke::new(LegacyColor::BLACK, 4.0),
+                Stroke::new(Color::BLACK, 4.0),
             ));
             parent.spawn((
                 ShapeBundle {
@@ -53,7 +53,7 @@ fn setup_system(mut commands: Commands) {
                     }),
                     ..default()
                 },
-                Stroke::new(LegacyColor::BLACK, 2.5),
+                Stroke::new(Color::BLACK, 2.5),
             ));
         });
 
@@ -84,7 +84,7 @@ fn setup_system(mut commands: Commands) {
                     }),
                     ..default()
                 },
-                Stroke::new(LegacyColor::BLACK, 20.0),
+                Stroke::new(Color::BLACK, 20.0),
             ));
 
             // shack walls
@@ -96,7 +96,7 @@ fn setup_system(mut commands: Commands) {
                     }),
                     ..default()
                 },
-                Stroke::new(LegacyColor::BLACK, 17.5),
+                Stroke::new(Color::BLACK, 17.5),
             ));
         });
 }

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -1,6 +1,6 @@
 //! Types for defining shape color and options.
 
-use bevy::{ecs::component::Component, render::color::LegacyColor};
+use bevy::{ecs::component::Component, render::color::Color};
 use lyon_tessellation::{FillOptions, StrokeOptions};
 
 /// Defines the fill options for the lyon tessellator and color of the generated
@@ -9,13 +9,13 @@ use lyon_tessellation::{FillOptions, StrokeOptions};
 #[derive(Component, Debug, Clone, Copy, PartialEq)]
 pub struct Fill {
     pub options: FillOptions,
-    pub color: LegacyColor,
+    pub color: Color,
 }
 
 impl Fill {
-    /// Convenience constructor requiring only the `LegacyColor`.
+    /// Convenience constructor requiring only the `Color`.
     #[must_use]
-    pub fn color(color: LegacyColor) -> Self {
+    pub fn color(color: Color) -> Self {
         Self {
             options: FillOptions::default(),
             color,
@@ -29,22 +29,22 @@ impl Fill {
 #[derive(Component, Debug, Clone, Copy, PartialEq)]
 pub struct Stroke {
     pub options: StrokeOptions,
-    pub color: LegacyColor,
+    pub color: Color,
 }
 
 impl Stroke {
-    /// Constructor that requires a `LegacyColor` and a line width.
+    /// Constructor that requires a `Color` and a line width.
     #[must_use]
-    pub fn new(color: LegacyColor, line_width: f32) -> Self {
+    pub fn new(color: Color, line_width: f32) -> Self {
         Self {
             options: StrokeOptions::default().with_line_width(line_width),
             color,
         }
     }
 
-    /// Convenience constructor requiring only the `LegacyColor`.
+    /// Convenience constructor requiring only the `Color`.
     #[must_use]
-    pub fn color(color: LegacyColor) -> Self {
+    pub fn color(color: Color) -> Self {
         Self {
             options: StrokeOptions::default(),
             color,

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -80,8 +80,8 @@ impl GeometryBuilder {
     ///             path: builder.build(),
     ///             ..default()
     ///         },
-    ///         Fill::color(LegacyColor::ORANGE_RED),
-    ///         Stroke::new(LegacyColor::ORANGE_RED, 10.0),
+    ///         Fill::color(Color::ORANGE_RED),
+    ///         Stroke::new(Color::ORANGE_RED, 10.0),
     ///     ));
     /// }
     /// # bevy::ecs::system::assert_is_system(my_system);
@@ -115,7 +115,7 @@ impl GeometryBuilder {
     ///             path: GeometryBuilder::build_as(&line),
     ///             ..default()
     ///         },
-    ///         Fill::color(LegacyColor::ORANGE_RED),
+    ///         Fill::color(Color::ORANGE_RED),
     ///     ));
     /// }
     /// # bevy::ecs::system::assert_is_system(my_system);

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -46,7 +46,7 @@ impl Plugin for ShapePlugin {
         app.world.resource_mut::<Assets<ColorMaterial>>().insert(
             COLOR_MATERIAL_HANDLE,
             ColorMaterial {
-                color: LegacyColor::WHITE,
+                color: Color::WHITE,
                 ..default()
             },
         );
@@ -85,7 +85,7 @@ fn mesh_shapes_system(
             fill(
                 &mut fill_tess,
                 &path.0,
-                &Fill::color(LegacyColor::FUCHSIA),
+                &Fill::color(Color::FUCHSIA),
                 &mut buffers,
             );
         }

--- a/src/vertex.rs
+++ b/src/vertex.rs
@@ -1,4 +1,4 @@
-use bevy::render::color::LegacyColor;
+use bevy::render::color::Color;
 use lyon_tessellation::{
     self as tess, FillVertex, FillVertexConstructor, StrokeVertex, StrokeVertexConstructor,
 };
@@ -19,7 +19,7 @@ pub struct Vertex {
 /// Zero-sized type used to implement various vertex construction traits from
 /// Lyon.
 pub struct VertexConstructor {
-    pub color: LegacyColor,
+    pub color: Color,
 }
 
 /// Enables the construction of a [`Vertex`] when using a `FillTessellator`.


### PR DESCRIPTION
Reverts Nilirad/bevy_prototype_lyon#240

`LegacyColor` has been removed. Reverting to make #242 easier to merge.