### PR TITLE
Update to bevy 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,22 @@ version = "0.8.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = ["bevy_sprite", "bevy_render", "bevy_core_pipeline", "bevy_asset"] }
+bevy = { version = "0.14.0-rc.3", default-features = false, features = [
+	"bevy_sprite",
+	"bevy_render",
+	"bevy_core_pipeline",
+	"bevy_asset",
+] }
 lyon_tessellation = "1"
 lyon_algorithms = "1"
 svgtypes = "0.8"
 
 [dev-dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = ["x11", "bevy_asset"] }
+bevy = { version = "0.14.0-rc.3", default-features = false, features = [
+	"x11",
+	"bevy_asset",
+	# TODO: Figure out if this will be needed https://github.com/bevyengine/bevy/issues/13728 
+	"ktx2",
+	"zstd",
+	"bevy_pbr",
+] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.8.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { version = "0.14.0-rc.3", default-features = false, features = [
+bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = [
 	"bevy_sprite",
 	"bevy_render",
 	"bevy_core_pipeline",
@@ -24,7 +24,7 @@ lyon_algorithms = "1"
 svgtypes = "0.8"
 
 [dev-dependencies]
-bevy = { version = "0.14.0-rc.3", default-features = false, features = [
+bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = [
 	"x11",
 	"bevy_asset",
 	# TODO: Figure out if this will be needed https://github.com/bevyengine/bevy/issues/13728 

--- a/examples/dynamic_shape.rs
+++ b/examples/dynamic_shape.rs
@@ -1,6 +1,6 @@
 use std::f64::consts::PI;
 
-use bevy::{color::palettes, prelude::*};
+use bevy::{color::palettes::css::*, prelude::*};
 use bevy_prototype_lyon::prelude::*;
 
 fn main() {
@@ -63,8 +63,8 @@ fn setup_system(mut commands: Commands) {
             path: GeometryBuilder::build_as(&shape),
             ..default()
         },
-        Fill::color(Color::Srgba(palettes::css::DARK_CYAN)),
-        Stroke::new(Color::Srgba(palettes::css::BLACK), 10.0),
+        Fill::color(DARK_CYAN),
+        Stroke::new(BLACK, 10.0),
         ExampleShape,
     ));
 }

--- a/examples/path.rs
+++ b/examples/path.rs
@@ -1,4 +1,4 @@
-use bevy::{color::palettes, prelude::*};
+use bevy::{color::palettes::css::*, prelude::*};
 use bevy_prototype_lyon::prelude::*;
 
 fn main() {
@@ -36,7 +36,7 @@ fn setup_system(mut commands: Commands) {
             },
             ..default()
         },
-        Stroke::new(Color::Srgba(palettes::css::BLACK), 10.0),
-        Fill::color(Color::Srgba(palettes::css::RED)),
+        Stroke::new(BLACK, 10.0),
+        Fill::color(RED),
     ));
 }

--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -1,7 +1,7 @@
 //! This is the example that goes to the README.md file. The README.md should be
 //! updated before every release.
 
-use bevy::{color::palettes, prelude::*};
+use bevy::{color::palettes::css::*, prelude::*};
 use bevy_prototype_lyon::prelude::*;
 
 fn main() {
@@ -26,7 +26,7 @@ fn setup_system(mut commands: Commands) {
             path: GeometryBuilder::build_as(&shape),
             ..default()
         },
-        Fill::color(Color::Srgba(palettes::css::DARK_CYAN)),
-        Stroke::new(Color::Srgba(palettes::css::BLACK), 10.0),
+        Fill::color(DARK_CYAN),
+        Stroke::new(BLACK, 10.0),
     ));
 }

--- a/examples/rounded_polygon.rs
+++ b/examples/rounded_polygon.rs
@@ -1,4 +1,4 @@
-use bevy::{color::palettes, prelude::*};
+use bevy::{color::palettes::css::*, prelude::*};
 use bevy_prototype_lyon::prelude::*;
 
 fn main() {
@@ -34,6 +34,6 @@ fn setup_system(mut commands: Commands) {
             path: GeometryBuilder::build_as(&shape),
             ..default()
         },
-        Fill::color(Color::Srgba(palettes::css::DARK_CYAN)),
+        Fill::color(DARK_CYAN),
     ));
 }

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -15,10 +15,10 @@ pub struct Fill {
 impl Fill {
     /// Convenience constructor requiring only the `Color`.
     #[must_use]
-    pub fn color(color: Color) -> Self {
+    pub fn color(color: impl Into<Color>) -> Self {
         Self {
             options: FillOptions::default(),
-            color,
+            color: color.into(),
         }
     }
 }
@@ -35,19 +35,19 @@ pub struct Stroke {
 impl Stroke {
     /// Constructor that requires a `Color` and a line width.
     #[must_use]
-    pub fn new(color: Color, line_width: f32) -> Self {
+    pub fn new(color: impl Into<Color>, line_width: f32) -> Self {
         Self {
             options: StrokeOptions::default().with_line_width(line_width),
-            color,
+            color: color.into(),
         }
     }
 
     /// Convenience constructor requiring only the `Color`.
     #[must_use]
-    pub fn color(color: Color) -> Self {
+    pub fn color(color: impl Into<Color>) -> Self {
         Self {
             options: StrokeOptions::default(),
-            color,
+            color: color.into(),
         }
     }
 }

--- a/src/vertex.rs
+++ b/src/vertex.rs
@@ -1,4 +1,4 @@
-use bevy::color::{Color, LinearRgba};
+use bevy::color::{Color, ColorToComponents};
 use lyon_tessellation::{
     self as tess, FillVertex, FillVertexConstructor, StrokeVertex, StrokeVertexConstructor,
 };
@@ -27,7 +27,7 @@ impl FillVertexConstructor<Vertex> for VertexConstructor {
     fn new_vertex(&mut self, vertex: FillVertex) -> Vertex {
         Vertex {
             position: [vertex.position().x, vertex.position().y],
-            color: LinearRgba::to_f32_array(&LinearRgba::from(self.color)),
+            color: self.color.to_linear().to_f32_array(),
         }
     }
 }
@@ -37,7 +37,7 @@ impl StrokeVertexConstructor<Vertex> for VertexConstructor {
     fn new_vertex(&mut self, vertex: StrokeVertex) -> Vertex {
         Vertex {
             position: [vertex.position().x, vertex.position().y],
-            color: LinearRgba::to_f32_array(&LinearRgba::from(self.color)),
+            color: self.color.to_linear().to_f32_array(),
         }
     }
 }


### PR DESCRIPTION
Notable changes:
- Made methods take in `impl<Color>` instead of Color.
- Added extra bevy feature flags to dev-dependencies because of this: https://github.com/bevyengine/bevy/pull/13734
     - This is only temporary, I think this is expected to get fixed in 0.14