### PR TITLE
Fix `Aabb`s and frustum culling by using default for `RenderAssetUsages`

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -132,7 +132,7 @@ fn stroke(
 fn build_mesh(buffers: &VertexBuffers) -> Mesh {
     let mut mesh = Mesh::new(
         PrimitiveTopology::TriangleList,
-        RenderAssetUsages::RENDER_WORLD,
+        RenderAssetUsages::default(),
     );
     mesh.insert_indices(Indices::U32(buffers.indices.clone()));
     mesh.insert_attribute(


### PR DESCRIPTION
Fixes #245 

Tested with a modified example with a lot of shapes, most of which are offscreen. FPS before: 7, after: 40.

```rust
use bevy::{
    color::palettes::css::*,
    prelude::*,
    window::{PresentMode, WindowResolution},
};
use bevy_prototype_lyon::prelude::*;
use rand::Rng;

fn main() {
    App::new()
        .insert_resource(Msaa::Sample4)
        .add_plugins((
            DefaultPlugins.set(WindowPlugin {
                primary_window: Some(Window {
                    resolution: WindowResolution::new(1920.0, 1080.0)
                        .with_scale_factor_override(1.0),
                    present_mode: PresentMode::AutoNoVsync,
                    ..default()
                }),
                ..default()
            }),
            ShapePlugin,
        ))
        .add_systems(Startup, setup_system)
        .run();
}

fn setup_system(mut commands: Commands) {
    let shape = shapes::RegularPolygon {
        sides: 6,
        feature: shapes::RegularPolygonFeature::Radius(20.0),
        ..shapes::RegularPolygon::default()
    };

    commands.spawn(Camera2dBundle::default());

    for _ in 0..100000 {
        commands.spawn((
            ShapeBundle {
                spatial: SpatialBundle::from_transform(Transform::from_xyz(
                    (rand::thread_rng().gen::<f32>() - 0.5) * 4000.,
                    (rand::thread_rng().gen::<f32>() - 0.5) * 4000.,
                    0.,
                )),
                path: GeometryBuilder::build_as(&shape),
                ..default()
            },
            Fill::color(DARK_CYAN),
            Stroke::new(BLACK, 10.0),
        ));
    }
}
```