### PR TITLE
Add support for border radii

### DIFF
--- a/examples/rectangle.rs
+++ b/examples/rectangle.rs
@@ -12,7 +12,7 @@ fn setup_system(mut commands: Commands) {
     let rect = shapes::Rectangle {
         extents: Vec2::splat(175.0),
         origin: RectangleOrigin::Center,
-        radii: Some(BorderRadii::single(25.0))
+        radii: Some(BorderRadii::single(25.0)),
     };
 
     commands.spawn((Camera2d, Msaa::Sample4));

--- a/examples/rectangle.rs
+++ b/examples/rectangle.rs
@@ -1,0 +1,27 @@
+use bevy::{color::palettes::css::*, prelude::*};
+use bevy_prototype_lyon::prelude::*;
+
+fn main() {
+    App::new()
+        .add_plugins((DefaultPlugins, ShapePlugin))
+        .add_systems(Startup, setup_system)
+        .run();
+}
+
+fn setup_system(mut commands: Commands) {
+    let rect = shapes::Rectangle {
+        extents: Vec2::splat(175.0),
+        origin: RectangleOrigin::Center,
+        radii: Some(BorderRadii::single(25.0))
+    };
+
+    commands.spawn((Camera2d, Msaa::Sample4));
+    commands.spawn((
+        ShapeBundle {
+            path: GeometryBuilder::build_as(&rect),
+            ..default()
+        },
+        Stroke::new(BLACK, 10.0),
+        Fill::color(RED),
+    ));
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,6 @@ pub mod prelude {
         geometry::{Geometry, GeometryBuilder},
         path::{PathBuilder, ShapePath},
         plugin::ShapePlugin,
-        shapes::{self, RectangleOrigin, BorderRadii, RegularPolygon, RegularPolygonFeature},
+        shapes::{self, BorderRadii, RectangleOrigin, RegularPolygon, RegularPolygonFeature},
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,6 @@ pub mod prelude {
         geometry::{Geometry, GeometryBuilder},
         path::{PathBuilder, ShapePath},
         plugin::ShapePlugin,
-        shapes::{self, RectangleOrigin, RegularPolygon, RegularPolygonFeature},
+        shapes::{self, RectangleOrigin, BorderRadii, RegularPolygon, RegularPolygonFeature},
     };
 }

--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -63,6 +63,7 @@ impl BorderRadii {
             bottom_right: radius,
         }
     }
+
     /// Use a single radius for the top corners and zero for the bottom corners.
     pub fn top(radius: f32) -> Self {
         Self {
@@ -71,6 +72,7 @@ impl BorderRadii {
             ..Default::default()
         }
     }
+
     /// Use a single radius for the bottom corners and zero for the top corners.
     pub fn bottom(radius: f32) -> Self {
         Self {
@@ -79,6 +81,7 @@ impl BorderRadii {
             ..Default::default()
         }
     }
+
     /// Use a single radius for the left corners and zero for the right corners.
     pub fn left(radius: f32) -> Self {
         Self {
@@ -87,6 +90,7 @@ impl BorderRadii {
             ..Default::default()
         }
     }
+
     /// Use a single radius for the right corners and zero for the left corners.
     pub fn right(radius: f32) -> Self {
         Self {

--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -9,8 +9,10 @@ use lyon_tessellation::{
     geom::euclid::default::Size2D,
     math::{point, Angle, Box2D, Point, Vector},
     path::{
-        builder::WithSvg, path::Builder, traits::SvgPathBuilder, ArcFlags, Polygon as LyonPolygon,
-        Winding,
+        builder::{BorderRadii as LyonBorderRadii, WithSvg},
+        path::Builder,
+        traits::SvgPathBuilder,
+        ArcFlags, Polygon as LyonPolygon, Winding,
     },
 };
 use svgtypes::{PathParser, PathSegment};
@@ -38,11 +40,81 @@ impl Default for RectangleOrigin {
     }
 }
 
+/// Radii for the four corners of a rectangle.
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub struct BorderRadii {
+    /// Radius for the top left corner.
+    pub top_left: f32,
+    /// Radius for the top right corner.
+    pub top_right: f32,
+    /// Radius for the bottom left corner.
+    pub bottom_left: f32,
+    /// Radius for the bottom right corner.
+    pub bottom_right: f32,
+}
+
+impl BorderRadii {
+    /// Use a single radius for all corners.
+    pub fn single(radius: f32) -> Self {
+        Self {
+            top_left: radius,
+            top_right: radius,
+            bottom_left: radius,
+            bottom_right: radius,
+        }
+    }
+    /// Use a single radius for the top corners and zero for the bottom corners.
+    pub fn top(radius: f32) -> Self {
+        Self {
+            top_left: radius,
+            top_right: radius,
+            ..Default::default()
+        }
+    }
+    /// Use a single radius for the bottom corners and zero for the top corners.
+    pub fn bottom(radius: f32) -> Self {
+        Self {
+            bottom_left: radius,
+            bottom_right: radius,
+            ..Default::default()
+        }
+    }
+    /// Use a single radius for the left corners and zero for the right corners.
+    pub fn left(radius: f32) -> Self {
+        Self {
+            top_left: radius,
+            bottom_left: radius,
+            ..Default::default()
+        }
+    }
+    /// Use a single radius for the right corners and zero for the left corners.
+    pub fn right(radius: f32) -> Self {
+        Self {
+            top_right: radius,
+            bottom_right: radius,
+            ..Default::default()
+        }
+    }
+}
+
+impl From<BorderRadii> for LyonBorderRadii {
+    fn from(source: BorderRadii) -> Self {
+        // swap top and bottom
+        LyonBorderRadii {
+            top_left: source.bottom_left.abs(),
+            top_right: source.bottom_right.abs(),
+            bottom_left: source.top_left.abs(),
+            bottom_right: source.top_right.abs(),
+        }
+    }
+}
+
 #[allow(missing_docs)]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Rectangle {
     pub extents: Vec2,
     pub origin: RectangleOrigin,
+    pub radii: Option<BorderRadii>,
 }
 
 impl Default for Rectangle {
@@ -50,6 +122,7 @@ impl Default for Rectangle {
         Self {
             extents: Vec2::ONE,
             origin: RectangleOrigin::default(),
+            radii: None,
         }
     }
 }
@@ -66,11 +139,13 @@ impl Geometry for Rectangle {
                 Point::new(v.x - self.extents.x / 2.0, v.y - self.extents.y / 2.0)
             }
         };
-
-        b.add_rectangle(
-            &Box2D::from_origin_and_size(origin, Size2D::new(self.extents.x, self.extents.y)),
-            Winding::Positive,
-        );
+        let rect =
+            &Box2D::from_origin_and_size(origin, Size2D::new(self.extents.x, self.extents.y));
+        let Some(radii) = self.radii else {
+            b.add_rectangle(rect, Winding::Positive);
+            return;
+        };
+        b.add_rounded_rectangle(rect, &radii.into(), Winding::Positive);
     }
 }
 


### PR DESCRIPTION
I have added support for border radii to `Rectangle`, and I have added a new example demonstrating this.