### PR TITLE
Remove the need for `PathBuilder`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.14.0
 
 This version uses Bevy's **Required Components**,
+along with other changes,
 therefore many items have been changed.
 Examples may help migration.
 
@@ -12,8 +13,10 @@ Examples may help migration.
 - Deprecated `ShapeBundle` in favor of the `Shape` component.
 - `prelude` no longer exports `ShapeBundle`.
 - Added `ShapeBuilder`: works similarly to `GeometryBuilder`
-- Removed `GeometryBuilder` and `ShapePath`.
-- `PathBuilder` now allows chaining methods.
+- Removed `GeometryBuilder` and `PathBuilder`.
+- `ShapePath` now works similarly to `PathBuilder`,
+  but implements `Geometry`,
+  so it has to be used with `ShapeBuilder`.
 
 ## 0.13.0
 - Support for Bevy 0.15.0.

--- a/examples/path.rs
+++ b/examples/path.rs
@@ -9,9 +9,7 @@ fn main() {
 }
 
 fn setup_system(mut commands: Commands) {
-    let shape = PathBuilder::new()
-        .fill(RED)
-        .stroke((BLACK, 10.0))
+    let path = ShapePath::new()
         .move_to(Vec2::new(0., 0.))
         .cubic_bezier_to(
             Vec2::new(70., 70.),
@@ -23,9 +21,14 @@ fn setup_system(mut commands: Commands) {
             Vec2::new(-70., 70.),
             Vec2::new(0., 0.),
         )
-        .close()
-        .build();
+        .close();
 
     commands.spawn((Camera2d, Msaa::Sample4));
-    commands.spawn((shape, Transform::from_xyz(0., 75., 0.)));
+    commands.spawn((
+        ShapeBuilder::with(&path)
+            .fill(RED)
+            .stroke((BLACK, 10.0))
+            .build(),
+        Transform::from_xyz(0., 75., 0.),
+    ));
 }

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -2,6 +2,7 @@
 #![expect(deprecated)]
 
 use bevy::prelude::*;
+use lyon_algorithms::path::Builder;
 use lyon_tessellation::{self as tess};
 
 use crate::{
@@ -69,8 +70,8 @@ impl Shape {
     }
 }
 
-impl Geometry for Shape {
-    fn add_geometry(&self, b: &mut tess::path::path::Builder) {
+impl Geometry<Builder> for Shape {
+    fn add_geometry(&self, b: &mut Builder) {
         b.extend_from_paths(&[self.path.as_slice()]);
     }
 }

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -1,5 +1,6 @@
 //! Types for defining and using geometries.
 
+use lyon_algorithms::path::{builder::WithSvg, BuilderImpl};
 use lyon_tessellation::path::path::Builder;
 
 use crate::{
@@ -38,7 +39,7 @@ use crate::{
 /// }
 ///
 /// // Finally, implement the `add_geometry` method.
-/// impl Geometry for Rectangle {
+/// impl Geometry<Builder> for Rectangle {
 ///     fn add_geometry(&self, b: &mut Builder) {
 ///         b.add_rectangle(
 ///             &Box2D::new(Point::zero(), Point::new(self.width, self.height)),
@@ -47,38 +48,38 @@ use crate::{
 ///     }
 /// }
 /// ```
-pub trait Geometry {
+pub trait Geometry<GenericBuilder> {
     /// Adds the geometry of the shape to the given Lyon path `Builder`.
-    fn add_geometry(&self, b: &mut Builder);
+    fn add_geometry(&self, b: &mut GenericBuilder);
 }
 
 /// Provides basic functionality common
 /// to [`ShapeBuilder`] and [`ReadyShapeBuilder`].
-pub trait ShapeBuilderBase {
+pub trait ShapeBuilderBase<GenericBuilder> {
     /// Adds a `Geometry` to the builder.
     #[must_use]
-    fn add(self, shape: &impl Geometry) -> Self;
+    fn add(self, shape: &impl Geometry<GenericBuilder>) -> Self;
 
     /// Sets the fill mode of the builder.
     #[must_use]
-    fn fill(self, fill: impl Into<Fill>) -> ReadyShapeBuilder;
+    fn fill(self, fill: impl Into<Fill>) -> ReadyShapeBuilder<GenericBuilder>;
 
     /// Sets the stroke mode of the builder.
     #[must_use]
-    fn stroke(self, stroke: impl Into<Stroke>) -> ReadyShapeBuilder;
+    fn stroke(self, stroke: impl Into<Stroke>) -> ReadyShapeBuilder<GenericBuilder>;
 }
 
 /// Provides methods for building a shape.
 #[derive(Default, Clone)]
-pub struct ShapeBuilder(Builder);
+pub struct ShapeBuilder<GenericBuilder>(GenericBuilder);
 
-impl ShapeBuilderBase for ShapeBuilder {
-    fn add(mut self, shape: &impl Geometry) -> Self {
+impl<GenericBuilder> ShapeBuilderBase<GenericBuilder> for ShapeBuilder<GenericBuilder> {
+    fn add(mut self, shape: &impl Geometry<GenericBuilder>) -> Self {
         shape.add_geometry(&mut self.0);
         self
     }
 
-    fn fill(self, fill: impl Into<Fill>) -> ReadyShapeBuilder {
+    fn fill(self, fill: impl Into<Fill>) -> ReadyShapeBuilder<GenericBuilder> {
         ReadyShapeBuilder {
             builder: self.0,
             fill: Some(fill.into()),
@@ -86,7 +87,7 @@ impl ShapeBuilderBase for ShapeBuilder {
         }
     }
 
-    fn stroke(self, stroke: impl Into<Stroke>) -> ReadyShapeBuilder {
+    fn stroke(self, stroke: impl Into<Stroke>) -> ReadyShapeBuilder<GenericBuilder> {
         ReadyShapeBuilder {
             builder: self.0,
             fill: None,
@@ -95,16 +96,19 @@ impl ShapeBuilderBase for ShapeBuilder {
     }
 }
 
-impl ShapeBuilder {
+impl<GenericBuilder> ShapeBuilder<GenericBuilder>
+where
+    GenericBuilder: LyonPathBuilderExt,
+{
     /// Constructs a new `ShapeBuilder`.
     #[must_use]
     pub fn new() -> Self {
-        Self(Builder::new())
+        Self(GenericBuilder::new())
     }
 
     /// Constructs a new `ShapeBuilder` with an initial `Geometry`.
     #[must_use]
-    pub fn with(geometry: &impl Geometry) -> Self {
+    pub fn with(geometry: &impl Geometry<GenericBuilder>) -> Self {
         Self::new().add(geometry)
     }
 }
@@ -113,36 +117,67 @@ impl ShapeBuilder {
 ///
 /// This struct can only be obtained by using [`ShapeBuilder`].
 #[derive(Clone)]
-pub struct ReadyShapeBuilder {
-    pub(crate) builder: Builder,
+pub struct ReadyShapeBuilder<GenericBuilder> {
+    pub(crate) builder: GenericBuilder,
     pub(crate) fill: Option<Fill>,
     pub(crate) stroke: Option<Stroke>,
 }
 
-impl ShapeBuilderBase for ReadyShapeBuilder {
-    fn add(mut self, shape: &impl Geometry) -> Self {
+impl<GenericBuilder> ShapeBuilderBase<GenericBuilder> for ReadyShapeBuilder<GenericBuilder> {
+    fn add(mut self, shape: &impl Geometry<GenericBuilder>) -> Self {
         shape.add_geometry(&mut self.builder);
         self
     }
 
-    fn fill(self, fill: impl Into<Fill>) -> ReadyShapeBuilder {
+    fn fill(self, fill: impl Into<Fill>) -> Self {
         Self {
             fill: Some(fill.into()),
             ..self
         }
     }
 
-    fn stroke(self, stroke: impl Into<Stroke>) -> ReadyShapeBuilder {
+    fn stroke(self, stroke: impl Into<Stroke>) -> Self {
         Self {
             stroke: Some(stroke.into()),
             ..self
         }
     }
 }
-impl ReadyShapeBuilder {
+
+/// Generalizes the implementation of the `build` method
+/// over multiple Lyon builders.
+pub trait ReadyShapeBuilderTrait {
     /// Builds a `Shape` according to the builder's settings.
-    #[allow(clippy::must_use_candidate)]
-    pub fn build(self) -> Shape {
+    fn build(self) -> Shape;
+}
+
+impl ReadyShapeBuilderTrait for ReadyShapeBuilder<Builder> {
+    fn build(self) -> Shape {
         Shape::new(self.builder.build(), self.fill, self.stroke)
+    }
+}
+
+impl ReadyShapeBuilderTrait for ReadyShapeBuilder<WithSvg<BuilderImpl>> {
+    fn build(self) -> Shape {
+        Shape::new(self.builder.build(), self.fill, self.stroke)
+    }
+}
+
+/// Extends `lyon` path builders with analogous methods
+/// under the same interface.
+pub trait LyonPathBuilderExt {
+    /// Creates a new path builder.
+    fn new() -> Self;
+}
+
+impl LyonPathBuilderExt for Builder {
+    fn new() -> Self {
+        Self::new()
+    }
+}
+
+impl LyonPathBuilderExt for WithSvg<BuilderImpl> {
+    fn new() -> Self {
+        Builder::new().with_svg()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,8 +43,8 @@ pub mod prelude {
     pub use crate::{
         draw::{Fill, Stroke},
         entity::Shape,
-        geometry::{Geometry, ShapeBuilder, ShapeBuilderBase},
         path::PathBuilder,
+        geometry::{Geometry, ReadyShapeBuilderTrait, ShapeBuilder, ShapeBuilderBase},
         plugin::ShapePlugin,
         shapes::{self, BorderRadii, RectangleOrigin, RegularPolygon, RegularPolygonFeature},
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,8 +43,8 @@ pub mod prelude {
     pub use crate::{
         draw::{Fill, Stroke},
         entity::Shape,
-        path::PathBuilder,
         geometry::{Geometry, ReadyShapeBuilderTrait, ShapeBuilder, ShapeBuilderBase},
+        path::ShapePath,
         plugin::ShapePlugin,
         shapes::{self, BorderRadii, RectangleOrigin, RegularPolygon, RegularPolygonFeature},
     };

--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -136,7 +136,7 @@ impl Default for Rectangle {
     }
 }
 
-impl Geometry for Rectangle {
+impl Geometry<Builder> for Rectangle {
     fn add_geometry(&self, b: &mut Builder) {
         let origin = match self.origin {
             RectangleOrigin::Center => Point::new(-self.extents.x / 2.0, -self.extents.y / 2.0),
@@ -174,7 +174,7 @@ impl Default for Circle {
     }
 }
 
-impl Geometry for Circle {
+impl Geometry<Builder> for Circle {
     fn add_geometry(&self, b: &mut Builder) {
         b.add_circle(self.center.to_point(), self.radius, Winding::Positive);
     }
@@ -196,7 +196,7 @@ impl Default for Ellipse {
     }
 }
 
-impl Geometry for Ellipse {
+impl Geometry<Builder> for Ellipse {
     fn add_geometry(&self, b: &mut Builder) {
         b.add_ellipse(
             self.center.to_point(),
@@ -223,7 +223,7 @@ impl Default for Polygon {
     }
 }
 
-impl Geometry for Polygon {
+impl Geometry<Builder> for Polygon {
     fn add_geometry(&self, b: &mut Builder) {
         let points = self
             .points
@@ -257,7 +257,7 @@ impl Default for RoundedPolygon {
     }
 }
 
-impl Geometry for RoundedPolygon {
+impl Geometry<Builder> for RoundedPolygon {
     fn add_geometry(&self, b: &mut Builder) {
         let points = self
             .points
@@ -320,7 +320,7 @@ impl Default for RegularPolygon {
     }
 }
 
-impl Geometry for RegularPolygon {
+impl Geometry<Builder> for RegularPolygon {
     fn add_geometry(&self, b: &mut Builder) {
         // -- Implementation details **PLEASE KEEP UPDATED** --
         // - `step`: angle between two vertices.
@@ -357,7 +357,7 @@ impl Geometry for RegularPolygon {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Line(pub Vec2, pub Vec2);
 
-impl Geometry for Line {
+impl Geometry<Builder> for Line {
     fn add_geometry(&self, b: &mut Builder) {
         b.add_polygon(LyonPolygon {
             points: &[self.0.to_point(), self.1.to_point()],
@@ -411,7 +411,7 @@ fn get_point_after_offset(x: f64, y: f64, offset_x: f32, offset_y: f32) -> Point
 fn get_corrected_relative_vector(x: f64, y: f64) -> Vector {
     Vector::new(x as f32, get_y_in_bevy_orientation(y))
 }
-impl Geometry for SvgPathShape {
+impl Geometry<Builder> for SvgPathShape {
     #[allow(clippy::too_many_lines)]
     fn add_geometry(&self, b: &mut Builder) {
         let builder = Builder::new();


### PR DESCRIPTION
This change allows `ShapeBuilder` to build custom paths. `PathBuilder` has been removed. Paths can be constructed with `ShapePath`, and then be feeded to `ShapeBuilder`.

Since normal shapes uses Lyon's type `NoAttribute<BuilderImpl>` while paths use `WithSvg<BuilderImpl>`, I made `Geometry` generic over these.