### PR TITLE
v0.14 update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,12 @@ license = "MIT OR Apache-2.0"
 name = "bevy_prototype_lyon"
 readme = "README.md"
 repository = "https://github.com/Nilirad/bevy_prototype_lyon/"
-version = "0.13.0"
+version = "0.14.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { version = "0.15.0", default-features = false, features = [
+bevy = { version = "0.16.0-rc.2", default-features = false, features = [
 	"bevy_sprite",
 	"bevy_render",
 	"bevy_core_pipeline",
@@ -24,4 +24,4 @@ lyon_algorithms = "1"
 svgtypes = "0.15"
 
 [dev-dependencies]
-bevy = "0.15.0"
+bevy = "0.16.0-rc.2"

--- a/deny.toml
+++ b/deny.toml
@@ -5,7 +5,7 @@ version = 2
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 ignore = [
-  "RUSTSEC-2022-0048", # xml-rs unmaintained
+  "RUSTSEC-2024-0436", # xml-rs unmaintained
 ]
 yanked = "deny"
 

--- a/examples/dynamic_shape.rs
+++ b/examples/dynamic_shape.rs
@@ -34,7 +34,7 @@ fn redraw_shape(mut query: Query<&mut Shape, With<ExampleShape>>, time: Res<Time
         ..shapes::RegularPolygon::default()
     };
 
-    let mut shape = query.single_mut();
+    let mut shape = query.single_mut().expect("Shape entity must always exist");
     *shape = ShapeBuilder::with(&polygon)
         .fill(color)
         .stroke((BLACK, outline_width as f32))

--- a/examples/dynamic_stroke_size.rs
+++ b/examples/dynamic_stroke_size.rs
@@ -45,7 +45,7 @@ fn rotate_shape_by_size(mut query: Query<(&mut Transform, &Shape)>, time: Res<Ti
 fn redraw_line_width(mut query: Query<&mut Shape, With<HexagonShape>>, time: Res<Time>) {
     let outline_width = 2.0 + time.elapsed_secs_f64().sin().abs() * 10.0;
 
-    let mut shape = query.single_mut();
+    let mut shape = query.single_mut().expect("Shape entity must always exist");
     shape.stroke = shape.stroke.map(|mut s| {
         s.options.line_width = outline_width as f32;
         s
@@ -57,7 +57,7 @@ fn redraw_fill(mut query: Query<&mut Shape, With<TriangleShape>>, time: Res<Time
     let hue = (time.elapsed_secs_f64() * 50.0) % 360.0;
     let color = Color::hsl(hue as f32, 1.0, 0.5);
 
-    let mut shape = query.single_mut();
+    let mut shape = query.single_mut().expect("Shape entity must always exist");
     shape.fill = shape.fill.map(|mut f| {
         f.color = color;
         f

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -39,7 +39,7 @@ impl Default for ShapeBundle {
 ///
 /// It can be constructed using `ShapeBuilder`.
 #[derive(Component, Default, Clone)]
-#[require(Mesh2d, MeshMaterial2d<ColorMaterial>(color_material_handle), Transform, Visibility)]
+#[require(Mesh2d, MeshMaterial2d<ColorMaterial> = color_material_handle(), Transform, Visibility)]
 #[non_exhaustive]
 pub struct Shape {
     /// Geometry of a shape.

--- a/src/path.rs
+++ b/src/path.rs
@@ -135,5 +135,5 @@ fn match_action(action: Action, b: &mut WithSvg<BuilderImpl>) {
         Action::Close => {
             b.close();
         }
-    };
+    }
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -4,6 +4,7 @@
 //! boilerplate.
 
 use bevy::{
+    asset::weak_handle,
     prelude::*,
     render::{mesh::Indices, render_asset::RenderAssetUsages, render_resource::PrimitiveTopology},
 };
@@ -16,7 +17,7 @@ use crate::{
 };
 
 pub(crate) const COLOR_MATERIAL_HANDLE: Handle<ColorMaterial> =
-    Handle::weak_from_u128(0x7CC6_61A1_0CD6_C147_129A_2C01_882D_9580);
+    weak_handle!("7cc661a1-0cd6-c147-129a-2c01882d9580");
 
 /// A plugin that provides resources and a system to draw shapes in Bevy with
 /// less boilerplate.


### PR DESCRIPTION
This version supports Bevy 0.16.

**Note:** The examples `dynamic_shape` and `dynamic_stroke_size` do not work properly, since the shapes aren't drawn. Unfortunately I don't have the time to investigate and fix the issue.