### PR TITLE
Update Bevy to 0.15.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,12 @@ license = "MIT OR Apache-2.0"
 name = "bevy_prototype_lyon"
 readme = "README.md"
 repository = "https://github.com/Nilirad/bevy_prototype_lyon/"
-version = "0.13.0"
+version = "0.13.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { version = "0.15.0", default-features = false, features = [
+bevy = { version = "0.15.3", default-features = false, features = [
 	"bevy_sprite",
 	"bevy_render",
 	"bevy_core_pipeline",
@@ -24,4 +24,4 @@ lyon_algorithms = "1"
 svgtypes = "0.15"
 
 [dev-dependencies]
-bevy = "0.15.0"
+bevy = "0.15.3"


### PR DESCRIPTION
Ran `cargo test` and `cargo clippy` -- all tests pass with no warnings or errors.