### PR TITLE
upgrade to bevy 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.13.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { version = "0.15.0", default-features = false, features = [
+bevy = { version = "0.16.0", default-features = false, features = [
 	"bevy_sprite",
 	"bevy_render",
 	"bevy_core_pipeline",
@@ -24,4 +24,4 @@ lyon_algorithms = "1"
 svgtypes = "0.15"
 
 [dev-dependencies]
-bevy = "0.15.0"
+bevy = "0.16.0"

--- a/examples/dynamic_shape.rs
+++ b/examples/dynamic_shape.rs
@@ -34,7 +34,11 @@ fn redraw_shape(mut query: Query<&mut Shape, With<ExampleShape>>, time: Res<Time
         ..shapes::RegularPolygon::default()
     };
 
-    let mut shape = query.single_mut();
+    let Ok(mut shape) = query.single_mut() else {
+        // TODO: how do we want to handle this?
+        return;
+    };
+
     *shape = ShapeBuilder::with(&polygon)
         .fill(color)
         .stroke((BLACK, outline_width as f32))

--- a/examples/dynamic_stroke_size.rs
+++ b/examples/dynamic_stroke_size.rs
@@ -45,7 +45,11 @@ fn rotate_shape_by_size(mut query: Query<(&mut Transform, &Shape)>, time: Res<Ti
 fn redraw_line_width(mut query: Query<&mut Shape, With<HexagonShape>>, time: Res<Time>) {
     let outline_width = 2.0 + time.elapsed_secs_f64().sin().abs() * 10.0;
 
-    let mut shape = query.single_mut();
+    let Ok(mut shape) = query.single_mut() else {
+        // TODO: how do we want to handle this?
+        return;
+    };
+
     shape.stroke = shape.stroke.map(|mut s| {
         s.options.line_width = outline_width as f32;
         s
@@ -57,7 +61,10 @@ fn redraw_fill(mut query: Query<&mut Shape, With<TriangleShape>>, time: Res<Time
     let hue = (time.elapsed_secs_f64() * 50.0) % 360.0;
     let color = Color::hsl(hue as f32, 1.0, 0.5);
 
-    let mut shape = query.single_mut();
+    let Ok(mut shape) = query.single_mut() else {
+        // TODO: how do we want to handle this?
+        return;
+    };
     shape.fill = shape.fill.map(|mut f| {
         f.color = color;
         f

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -39,7 +39,7 @@ impl Default for ShapeBundle {
 ///
 /// It can be constructed using `ShapeBuilder`.
 #[derive(Component, Default, Clone)]
-#[require(Mesh2d, MeshMaterial2d::<ColorMaterial>, Transform, Visibility)]
+#[require(Mesh2d, MeshMaterial2d::<ColorMaterial>(COLOR_MATERIAL_HANDLE), Transform, Visibility)]
 #[non_exhaustive]
 pub struct Shape {
     /// Geometry of a shape.
@@ -60,8 +60,4 @@ impl Geometry<Builder> for Shape {
     fn add_geometry(&self, b: &mut Builder) {
         b.extend_from_paths(&[self.path.as_slice()]);
     }
-}
-
-fn color_material_handle() -> MeshMaterial2d<ColorMaterial> {
-    MeshMaterial2d(COLOR_MATERIAL_HANDLE)
 }

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -39,7 +39,7 @@ impl Default for ShapeBundle {
 ///
 /// It can be constructed using `ShapeBuilder`.
 #[derive(Component, Default, Clone)]
-#[require(Mesh2d, MeshMaterial2d<ColorMaterial>(color_material_handle), Transform, Visibility)]
+#[require(Mesh2d, MeshMaterial2d::<ColorMaterial>, Transform, Visibility)]
 #[non_exhaustive]
 pub struct Shape {
     /// Geometry of a shape.

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -7,6 +7,7 @@ use bevy::{
     prelude::*,
     render::{mesh::Indices, render_asset::RenderAssetUsages, render_resource::PrimitiveTopology},
 };
+use bevy::asset::weak_handle;
 use lyon_tessellation::{self as tess, BuffersBuilder};
 
 use crate::{
@@ -16,7 +17,7 @@ use crate::{
 };
 
 pub(crate) const COLOR_MATERIAL_HANDLE: Handle<ColorMaterial> =
-    Handle::weak_from_u128(0x7CC6_61A1_0CD6_C147_129A_2C01_882D_9580);
+    weak_handle!("7cc661a1-0cd6-c147-129a-2c01882d9580");
 
 /// A plugin that provides resources and a system to draw shapes in Bevy with
 /// less boilerplate.


### PR DESCRIPTION
first attempt at upgrading `bevy_prototype_lyon` to Bevy 0.16
so far it compiles, tests pass and examples seem to run.

The first two examples (`dynamic_shape` and `dynamic_stroke_size`) have some issues.
`dynamic_shape` seems to have some flickering going I can't seem to get rid off while `dynamic_stroke_size` doesn't render the shapes as soon as you try to update them.

Both examples stop working as soon as `Update` schedule touches them, but I can't seem to figure out why or how.

Any help here is greatly appreciated