### PR TITLE
Update Bevy to 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.15.0
+
+- Support for Bevy 0.16.0.
+
 ## 0.14.0
 
 This version uses Bevy's **Required Components**,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,8 +68,9 @@ Make sure to explain the motivation behind the desired change.
 Keep in mind that some suggestions
 may have side effects
 that negatively impact established use cases.
-Therefore they should be thoroughly discussed
+Therefore, they should be thoroughly discussed
 before implementing them.
 
 [issues]: https://github.com/Nilirad/bevy_prototype_lyon/issues
+
 [pull requests]: https://docs.github.com/en/pull-requests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,20 +8,20 @@ license = "MIT OR Apache-2.0"
 name = "bevy_prototype_lyon"
 readme = "README.md"
 repository = "https://github.com/Nilirad/bevy_prototype_lyon/"
-version = "0.13.0"
+version = "0.15.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { version = "0.15.0", default-features = false, features = [
-	"bevy_sprite",
-	"bevy_render",
-	"bevy_core_pipeline",
-	"bevy_asset",
+bevy = { version = "0.16.0", default-features = false, features = [
+    "bevy_sprite",
+    "bevy_render",
+    "bevy_core_pipeline",
+    "bevy_asset",
 ] }
 lyon_tessellation = "1"
 lyon_algorithms = "1"
 svgtypes = "0.15"
 
 [dev-dependencies]
-bevy = "0.15.0"
+bevy = "0.16.0"

--- a/README.md
+++ b/README.md
@@ -61,20 +61,22 @@ I strive to support the latest version of Bevy. Support for a version of Bevy is
 
 The following table shows the latest version of `bevy_prototype_lyon` that supports a certain version of Bevy.
 
-|bevy|bevy_prototype_lyon|license|
-|---|---|---|
-|0.15|0.13|MIT/Apache 2.0|
-|0.14|0.12|MIT/Apache 2.0|
-|0.13|0.11|MIT/Apache 2.0|
-|0.12|0.10|MIT/Apache 2.0|
-|0.11|0.9|MIT/Apache 2.0|
-|0.10|0.8|MIT/Apache 2.0|
-|0.9 |0.7|MIT/Apache 2.0|
-|0.8 |0.6|MIT/Apache 2.0|
-|0.7 |0.5|MIT/Apache 2.0|
-|0.6 |0.4|MIT/Apache 2.0|
-|0.5 |0.3|MIT|
-|0.4 |0.2|MIT|
+| bevy | bevy_prototype_lyon | license        |
+|------|---------------------|----------------|
+| 0.16 | 0.15                | MIT/Apache 2.0 |
+| 0.15 | 0.14                | MIT/Apache 2.0 |
+| 0.15 | 0.13                | MIT/Apache 2.0 |
+| 0.14 | 0.12                | MIT/Apache 2.0 |
+| 0.13 | 0.11                | MIT/Apache 2.0 |
+| 0.12 | 0.10                | MIT/Apache 2.0 |
+| 0.11 | 0.9                 | MIT/Apache 2.0 |
+| 0.10 | 0.8                 | MIT/Apache 2.0 |
+| 0.9  | 0.7                 | MIT/Apache 2.0 |
+| 0.8  | 0.6                 | MIT/Apache 2.0 |
+| 0.7  | 0.5                 | MIT/Apache 2.0 |
+| 0.6  | 0.4                 | MIT/Apache 2.0 |
+| 0.5  | 0.3                 | MIT            |
+| 0.4  | 0.2                 | MIT            |
 
 ***
 
@@ -82,8 +84,8 @@ The following table shows the latest version of `bevy_prototype_lyon` that suppo
 
 Licensed under either of
 
- * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
- * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+* MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
 
 at your option.
 

--- a/examples/dynamic_shape.rs
+++ b/examples/dynamic_shape.rs
@@ -34,11 +34,12 @@ fn redraw_shape(mut query: Query<&mut Shape, With<ExampleShape>>, time: Res<Time
         ..shapes::RegularPolygon::default()
     };
 
-    let mut shape = query.single_mut();
-    *shape = ShapeBuilder::with(&polygon)
-        .fill(color)
-        .stroke((BLACK, outline_width as f32))
-        .build();
+    if let Ok(mut shape) = query.single_mut() {
+        *shape = ShapeBuilder::with(&polygon)
+            .fill(color)
+            .stroke((BLACK, outline_width as f32))
+            .build();
+    }
 }
 
 fn setup_system(mut commands: Commands) {

--- a/examples/dynamic_stroke_size.rs
+++ b/examples/dynamic_stroke_size.rs
@@ -45,11 +45,12 @@ fn rotate_shape_by_size(mut query: Query<(&mut Transform, &Shape)>, time: Res<Ti
 fn redraw_line_width(mut query: Query<&mut Shape, With<HexagonShape>>, time: Res<Time>) {
     let outline_width = 2.0 + time.elapsed_secs_f64().sin().abs() * 10.0;
 
-    let mut shape = query.single_mut();
-    shape.stroke = shape.stroke.map(|mut s| {
-        s.options.line_width = outline_width as f32;
-        s
-    });
+    if let Ok(mut shape) = query.single_mut() {
+        shape.stroke = shape.stroke.map(|mut s| {
+            s.options.line_width = outline_width as f32;
+            s
+        });
+    }
 }
 
 /// Change fill color of the triangle over time.
@@ -57,11 +58,12 @@ fn redraw_fill(mut query: Query<&mut Shape, With<TriangleShape>>, time: Res<Time
     let hue = (time.elapsed_secs_f64() * 50.0) % 360.0;
     let color = Color::hsl(hue as f32, 1.0, 0.5);
 
-    let mut shape = query.single_mut();
-    shape.fill = shape.fill.map(|mut f| {
-        f.color = color;
-        f
-    });
+    if let Ok(mut shape) = query.single_mut() {
+        shape.fill = shape.fill.map(|mut f| {
+            f.color = color;
+            f
+        });
+    }
 }
 
 fn setup_system(mut commands: Commands) {

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -39,7 +39,7 @@ impl Default for ShapeBundle {
 ///
 /// It can be constructed using `ShapeBuilder`.
 #[derive(Component, Default, Clone)]
-#[require(Mesh2d, MeshMaterial2d<ColorMaterial>(color_material_handle), Transform, Visibility)]
+#[require(Mesh2d, MeshMaterial2d<ColorMaterial> = color_material_handle(), Transform, Visibility)]
 #[non_exhaustive]
 pub struct Shape {
     /// Geometry of a shape.

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -6,6 +6,7 @@
 use bevy::{
     prelude::*,
     render::{mesh::Indices, render_asset::RenderAssetUsages, render_resource::PrimitiveTopology},
+    asset::weak_handle
 };
 use lyon_tessellation::{self as tess, BuffersBuilder};
 
@@ -16,7 +17,7 @@ use crate::{
 };
 
 pub(crate) const COLOR_MATERIAL_HANDLE: Handle<ColorMaterial> =
-    Handle::weak_from_u128(0x7CC6_61A1_0CD6_C147_129A_2C01_882D_9580);
+    weak_handle!("7cc661a1-0cd6-c147-129a-2c01882d9580");
 
 /// A plugin that provides resources and a system to draw shapes in Bevy with
 /// less boilerplate.


### PR DESCRIPTION
This change updates Bevy version to 0.16.0.

Notable changes:

* use `weak_handle!` macro instead of deprecated `Handle::from_weak()`
* `Query::single_mut` now returns `Result<T>`
* use `=` syntax for required components