### PR TITLE
Update repository link and authors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,8 @@
 [package]
-authors = ["Federico Rinaldi <gisquerin@gmail.com>"]
+authors = [
+	"Federico Rinaldi <gisquerin@gmail.com>",
+	"Rob Parrett <robparrett@gmail.com>",
+]
 categories = ["game-engines", "graphics", "rendering"]
 description = "Draw 2D shapes and paths in the Bevy game engine."
 edition = "2021"
@@ -7,7 +10,7 @@ keywords = ["game", "shapes", "gamedev", "graphics", "bevy"]
 license = "MIT OR Apache-2.0"
 name = "bevy_prototype_lyon"
 readme = "README.md"
-repository = "https://github.com/Nilirad/bevy_prototype_lyon/"
+repository = "https://github.com/rparrett/bevy_prototype_lyon/"
 version = "0.14.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
The crate has moved from `nilirad/bevy_prototype_lyon` to `rparrett/bevy_prototype_lyon`.