### PR TITLE
Prepare for 0.17 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.17.0
+
+* Upgrade to Bevy 0.19 by @rparrett in <https://github.com/rparrett/bevy_prototype_lyon/pull/298>
+
 ## 0.16.0
 
 * Fix inverted SVG arc sweep by @rparrett in <https://github.com/rparrett/bevy_prototype_lyon/pull/294>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 name = "bevy_prototype_lyon"
 readme = "README.md"
 repository = "https://github.com/rparrett/bevy_prototype_lyon/"
-version = "0.16.0"
+version = "0.17.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The following table shows the latest version of `bevy_prototype_lyon` that suppo
 
 |bevy|bevy_prototype_lyon|license|
 |---|---|---|
+|0.19|0.17|MIT/Apache 2.0|
 |0.18|0.16|MIT/Apache 2.0|
 |0.17|0.15|MIT/Apache 2.0|
 |0.16|0.14|MIT/Apache 2.0|


### PR DESCRIPTION
- [X] version compatibility table
- [X] changelog
- [X] CI green
- [X] `cargo publish --dry-run`
- [X] merge
- [X] `cargo publish`
- [X] GH release